### PR TITLE
Reduce the garbage collection overhead of repeated calls to overlaps

### DIFF
--- a/lib/src/r_tree/r_tree_contributor.dart
+++ b/lib/src/r_tree/r_tree_contributor.dart
@@ -20,9 +20,15 @@ part of r_tree;
 abstract class RTreeContributor {
   Rectangle get rect;
 
-  // Rectangles that share only a border are not considered to overlap
+  // Calculate if otherRect overlaps with the current rectangle
+  //
+  // This function is a replication of Rectangle.intersects. It differs in that
+  // the inequalities are strict and do not allow for equivalences. This means
+  // that the two rectangles are not considered overlapping if they share an edge.
   bool overlaps(Rectangle otherRect) {
-    Rectangle intersection = rect.intersection(otherRect);
-    return intersection != null && intersection.height > 0 && intersection.width > 0;
+    return (rect.left < otherRect.left + otherRect.width &&
+        otherRect.left < rect.left + rect.width &&
+        rect.top < otherRect.top + otherRect.height &&
+        otherRect.top < rect.top + rect.height);
   }
 }


### PR DESCRIPTION
rect.intersection creates a third rectangle which we only need because rect.intersects counts "touching" as intersecting.
In order to work around this, use a custom intersection algorithm that does not allow equality in the checks

@tayloranderson-wf @kyleshattuck-wf 