### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:math';
 
 import 'package:benchmark_harness/benchmark_harness.dart';

--- a/benchmark/web_benchmarks.dart
+++ b/benchmark/web_benchmarks.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:html';
 
 import 'benchmarks.dart' as benchmarks;

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:async';
 import 'dart:html';
 import 'package:r_tree/r_tree.dart';

--- a/test/r_tree/leaf_node_test.dart
+++ b/test/r_tree/leaf_node_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 library leaf_node;
 
 import 'dart:math';

--- a/test/r_tree/node_test.dart
+++ b/test/r_tree/node_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 library node_test;
 
 import 'dart:math';

--- a/test/r_tree/non_leaf_node_test.dart
+++ b/test/r_tree/non_leaf_node_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 library non_leaf_node;
 
 import 'dart:math';

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 library r_tree;
 
 import 'dart:math';

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 
 // Copyright 2017 Workiva Inc.
 //


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)