### PR TITLE
Fix wildcard to include branch names with slashes

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -6,7 +6,7 @@ on:
       - 'master'
   pull_request:
     branches:
-      - '*'
+      - '**'
 
 jobs:
   test:


### PR DESCRIPTION
From [the GitHub Actions docs](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags):

> The `*` wildcard matches any character, but does not match slash (`/`).
>
> The `**` wildcard matches any character including slash (`/`) in branch and tag names.

This PR updates to use `**` instead of `*` so that GitHub Actions run on all branches, as opposed to skipping branches containing slashes.