### PR TITLE
Raise More Max Versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,8 @@ dev_dependencies:
   build_test: ^0.10.9
   build_web_compilers: ^2.12.0
   dart_dev: ^3.0.0
-  dart_style: ^1.3.1
-  dependency_validator: ^2.0.0
+  dart_style: '>=1.3.1 <3.0.0'
+  dependency_validator: '>=2.0.0 <4.0.0'
   meta: ">=1.2.2 <1.7.0"
   test: ^1.15.7
 


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating more dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This updates the maximum for the following packages (leaving the minimum unchanged)

  pubspec_codemod raise-max build_runner 3.0.0 --recursive
  pubspec_codemod raise-max crypto 4.0.0 --recursive
  pubspec_codemod raise-max dart_style 3.0.0 --recursive
  pubspec_codemod raise-max dependency_validator 4.0.0 --recursive
  pubspec_codemod raise-max io 2.0.0 --recursive
  pubspec_codemod raise-max mime 2.0.0 --recursive
  pubspec_codemod raise-max quiver 4.0.0 --recursive
  pubspec_codemod raise-max stream_transform 3.0.0 --recursive
  pubspec_codemod raise-max tuple 3.0.0 --recursive
  pubspec_codemod raise-max uuid 4.0.0 --recursive
  pubspec_codemod raise-max yaml 4.0.0 --recursive

**How do we know these ranges are safe?**

  - `build_runner`, `dart_style`, and `dependency_validator` are all only used for their executables and shouldn't introduce any breaking changes. Note that as your package resolves to newer versions of `dart_style`, it's _possible_ that you may need to commit some updated formatting changes.
  
  - `crypto` v3 is the NNBD migration and has one breaking change, which is to remove a `newInstance()` method on some classes. We have [no usages of this method](https://sourcegraph.plat.workiva.net/search?q=content%3A%27package%3Acrypto%2F%27+and+newInstance).
  
  - `io` v1, `mime` v1, `stream_transform` v2, and `tuple` v2 are all NNBD migrations.

  - `quiver` v3 has breaking changes, so we ran a [batch change with a dependency override to verify compatibility](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_quiver_v3). We did identify one package affected by these breaking changes, which has already [been remediated](https://github.com/Workiva/drawing/pull/561).

  - `uuid` v2 and v3 have some breaking changes, so we ran a [batch change with a dependency override to verify compatibility](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_uuid_v3) We identified and [fixed 1 test that was affected by the uuid change.](https://github.com/Workiva/app_intelligence_dart/pull/942)

  - `yaml` v3 has one breaking change, which is that optional `sourceUrl` param in the `loadYaml` function is now typed as `Uri` instead of `dynamic` (previously it allowed `String`, as well). We have already addressed our [own usages](https://sourcegraph.plat.workiva.net/search?q=context:global+loadYaml%28...sourceUrl...%29&patternType=structural) of this parameter to use `Uri`s.

  While we're confident these newer versions should be safe to consume, we can't say for sure. Please reach out to us if you encounter any issues that you think may be related.

For more info, reach out to `#support-frontend-architecture` on Slack.

[_Created by Sourcegraph batch change `Workiva/raise_more_max_versions`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/raise_more_max_versions)