### PR TITLE
Raise analyzer minimum & unpin meta

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [ stable, 2.13.4, dev ]
+        sdk: [ 2.13.4, 2.18.7 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dev_dependencies:
   benchmark_harness: any
   build_runner: '>=1.7.1 <3.0.0'
-  build_test: ^0.10.9
+  build_test: ^1.0.0
   build_web_compilers: ^2.12.0
   dart_dev: ^3.0.0
   dart_style: '>=1.3.1 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
   dart_dev: ^3.0.0
   dart_style: '>=1.3.1 <3.0.0'
   dependency_validator: ^2.0.0
-  meta: ">=1.2.2 <1.7.0"
+  meta: ^1.6.0
   test: ^1.15.7
 
 dependency_validator: 


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This will require analyzer 1.7.2+ and now that we're past analyzer 1.7.1
we can unpin the meta dependency. (We had restricted it to <1.7.0 in many places)

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/analyzer1_unpin_meta`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/analyzer1_unpin_meta)