### PR TITLE
Remove dart_dev, minor fixes

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sdk: [ 2.13.4, 2.18.7 ]
+        sdk: [ 2.18.7, 2.19.2 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1
@@ -25,7 +25,7 @@ jobs:
         run: dart run dependency_validator
       - name: Check formatting
         run: dart format --output=none --set-exit-if-changed .
-        if: ${{ matrix.sdk == '2.13.4' }}
+        if: ${{ matrix.sdk == '2.18.7' }}
       - name: Analyze project source
         run: dart analyze
       - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.13
+FROM google/dart:2.18
 WORKDIR /build/
 ADD pubspec.yaml /build/
 RUN dart pub get

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.18
+FROM dart:2.18.7
 WORKDIR /build/
 ADD pubspec.yaml /build/
 RUN dart pub get

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A recursive RTree library written in Dart. This R-tree implementation is used to
 
 Run the example app for a visual demonstration of the RTree
 ```
-pub serve example
+webdev serve example:8080
 ```
 Navigate to `http://localhost:8080`.  A canvas is drawn, click & drag on the canvas to add rectangles of various colors to your RTree, then click the search button and click & drag over an area of the canvas to search it for rectangles.
 
@@ -19,4 +19,4 @@ Run the benchmarks in the command line (Dart VM) using:
 dart benchmark/benchmarks.dart
 ```
 
-You can also run them in a browser using dart2js using `pub serve benchmark` or `pub build benchmark` and then serving them with your http server of choice.  Click the run button and observe the output in the browser console.
+You can also run them in a browser using dart2js using `webdev serve benchmark` or `webdev build benchmark` and then serving them with your http server of choice.  Click the run button and observe the output in the browser console.

--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -36,7 +36,7 @@ class InsertBenchmark extends RTreeBenchmarkBase {
       int y = rand.nextInt(100000);
       int height = rand.nextInt(100);
       int width = rand.nextInt(100);
-      RTreeDatum item = RTreeDatum(Rectangle(x, y, width, height), 'item $i');
+      RTreeDatum item = RTreeDatum<String>(Rectangle(x, y, width, height), 'item $i');
       tree.insert(item);
     }
   }

--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -36,7 +36,8 @@ class InsertBenchmark extends RTreeBenchmarkBase {
       int y = rand.nextInt(100000);
       int height = rand.nextInt(100);
       int width = rand.nextInt(100);
-      RTreeDatum item = RTreeDatum<String>(Rectangle(x, y, width, height), 'item $i');
+      RTreeDatum item =
+          RTreeDatum<String>(Rectangle(x, y, width, height), 'item $i');
       tree.insert(item);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ dev_dependencies:
   build_runner: '>=1.7.1 <3.0.0'
   build_test: ^1.0.0
   build_web_compilers: ^2.12.0
-  dart_dev: ^3.0.0
   dart_style: '>=1.3.1 <3.0.0'
   dependency_validator: ^2.0.0
   meta: ^1.6.0

--- a/tool/dart_dev/config.dart
+++ b/tool/dart_dev/config.dart
@@ -1,6 +1,0 @@
-import 'package:dart_dev/dart_dev.dart';
-
-final Map<String, DevTool> config = {
-  ...coreConfig,
-  'serve': WebdevServeTool()..buildArgs = ['example'],
-};


### PR DESCRIPTION
## Summary

Prepare for null safety migration by removing the last dependency that was not null safe. dart_dev wasn't being used in CI anyway, so it was easier to remove it and just use the built in dart commands.