### PR TITLE
Fix removal benchmark and add reference benchmarks for RBush to contextualize results.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,4 +13,8 @@ dev_dependencies:
   build_web_compilers: ^3.2.7
   dart_style: ^2.2.4
   dependency_validator: ^3.0.0
+  rbush: ^1.1.0
   test: ^1.15.7
+
+dependencies:
+  #


### PR DESCRIPTION
Hey folks,

I was looking for a geospatial index in dart and was pleasantly surprised that there were even two r-tree implementations. I was also very pleasantly surprised that you folks had benchmarks, which gave me confidence that you are serious about performance :+1: . Still wanting to do due diligence, I took your benchmark as a starting point to compare the two implementations and sure enough your implementation has short off 3x faster lookups for 5k entries and 2x for 30k entries :clap: . For tree maintenance tasks, like insertions and removals, things look a little different.

I wanted to share my results with you and also offer you the code to provide a reference point for potential future work/improvements.

I also wanted to use the opportunity to do a minor cleanup and point out that your removal benchmark is likely not working as intended (my change fixes that ), i.e. the removal benchmark is trying to delete nodes from an empty tree after incorrectly setting up the contents.

Thanks for r_tee :rocket: 

---------

Results:

Name    Result (microseconds)
Insert 5k       3974499.5
RBush Insert 5k 3758515.0  (0.95x)
RBush Load 5k    684047.5  (0.17x)

Remove 5k       101503.80952380953
RBush Remove 5k  14187.377622377622 (0.14x)

Search 5k           49910.46341463415
RBush Search  5k   136266.8125      (2.73x)
List Search  5k   1031754.5         (20.7x)

Search 30k      886006.6666666666
RBush Search  30k       1644147.0   (1.86x)