### PR TITLE
DT-23024 Bulk loading

### DIFF
--- a/.github/workflows/dart_ci.yaml
+++ b/.github/workflows/dart_ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Validate dependencies
         run: dart run dependency_validator
       - name: Check formatting
-        run: dart format --output=none --set-exit-if-changed .
+        run: dart format -l 120 --output=none --set-exit-if-changed .
         if: ${{ matrix.sdk == '2.18.7' }}
       - name: Analyze project source
         run: dart analyze

--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -77,8 +77,8 @@ class InsertBenchmark extends RTreeBenchmarkBase {
 class LoadBenchmark extends RTreeBenchmarkBase {
   LoadBenchmark(ScoreCollector collector) : super("Load 5k ", collector);
 
-  RTree<String> tree;
-  List<RTreeDatum<String>> datum;
+  late RTree<String> tree;
+  late List<RTreeDatum<String>> datum;
 
   void run() {
     tree = RTree<String>(BRANCH_FACTOR);
@@ -93,7 +93,7 @@ class LoadBenchmark extends RTreeBenchmarkBase {
       int y = rand.nextInt(100000);
       int height = rand.nextInt(100);
       int width = rand.nextInt(100);
-      RTreeDatum item =
+      final item =
           RTreeDatum<String>(Rectangle(x, y, width, height), 'item $i');
       datum.add(item);
     }

--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -13,9 +13,11 @@ main() {
   LoadBenchmark(collector).report();
   RemoveBenchmark(collector).report();
   SearchBenchmark1(collector).report();
-  SearchBenchmark2(collector).report();
   SearchBenchmark1(collector, iterateAll: true).report();
+  SearchBenchmark1(collector, iterateAll: true, useLoad: true).report();
+  SearchBenchmark2(collector).report();
   SearchBenchmark2(collector, iterateAll: true).report();
+  SearchBenchmark2(collector, iterateAll: true, useLoad: true).report();
 
   var longestName = collector.collected.keys
       .reduce(
@@ -135,9 +137,17 @@ class RemoveBenchmark extends RTreeBenchmarkBase {
 }
 
 class SearchBenchmark1 extends RTreeBenchmarkBase {
+  /// Allows comparing search performance if the results are iterated or not.
   final bool iterateAll;
-  SearchBenchmark1(ScoreCollector collector, {this.iterateAll = false})
-      : super("Search${iterateAll ? '/Iterate' : ''} 5k", collector);
+
+  /// Allows comparing search performance between trees built out via insert or load
+  final bool useLoad;
+
+  SearchBenchmark1(ScoreCollector collector,
+      {this.iterateAll = false, this.useLoad = false})
+      : super(
+            "Search${iterateAll ? '/Iterate' : ''} ${useLoad ? 'using Load' : ''} 5k",
+            collector);
 
   RTree<String> tree;
 
@@ -158,20 +168,27 @@ class SearchBenchmark1 extends RTreeBenchmarkBase {
   void setup() {
     tree = RTree(BRANCH_FACTOR);
 
+    var datum = <RTreeDatum<String>>[];
     for (int i = 0; i < 10; i++) {
       for (int j = 0; j < 50; j++) {
         Rectangle rect = Rectangle(i, j, 1, 1);
-        tree.insert(RTreeDatum<String>(rect, 'item1'));
-        tree.insert(RTreeDatum<String>(rect, 'item2'));
-        tree.insert(RTreeDatum<String>(rect, 'item3'));
-        tree.insert(RTreeDatum<String>(rect, 'item4'));
-        tree.insert(RTreeDatum<String>(rect, 'item5'));
-        tree.insert(RTreeDatum<String>(rect, 'item6'));
-        tree.insert(RTreeDatum<String>(rect, 'item7'));
-        tree.insert(RTreeDatum<String>(rect, 'item8'));
-        tree.insert(RTreeDatum<String>(rect, 'item9'));
-        tree.insert(RTreeDatum<String>(rect, 'item10'));
+        datum.add(RTreeDatum<String>(rect, 'item1'));
+        datum.add(RTreeDatum<String>(rect, 'item2'));
+        datum.add(RTreeDatum<String>(rect, 'item3'));
+        datum.add(RTreeDatum<String>(rect, 'item4'));
+        datum.add(RTreeDatum<String>(rect, 'item5'));
+        datum.add(RTreeDatum<String>(rect, 'item6'));
+        datum.add(RTreeDatum<String>(rect, 'item7'));
+        datum.add(RTreeDatum<String>(rect, 'item8'));
+        datum.add(RTreeDatum<String>(rect, 'item9'));
+        datum.add(RTreeDatum<String>(rect, 'item10'));
       }
+    }
+
+    if (useLoad) {
+      tree.load(datum);
+    } else {
+      datum.forEach(tree.insert);
     }
   }
 
@@ -179,10 +196,17 @@ class SearchBenchmark1 extends RTreeBenchmarkBase {
 }
 
 class SearchBenchmark2 extends RTreeBenchmarkBase {
+  /// Allows comparing search performance if the results are iterated or not.
   final bool iterateAll;
 
-  SearchBenchmark2(ScoreCollector collector, {this.iterateAll = false})
-      : super("Search${iterateAll ? '/Iterate' : ''} 30k", collector);
+  /// Allows comparing search performance between trees built out via insert or load
+  final bool useLoad;
+
+  SearchBenchmark2(ScoreCollector collector,
+      {this.iterateAll = false, this.useLoad = false})
+      : super(
+            "Search${iterateAll ? '/Iterate' : ''} ${useLoad ? 'using Load' : ''} 30k",
+            collector);
 
   RTree<String> tree;
 
@@ -203,13 +227,20 @@ class SearchBenchmark2 extends RTreeBenchmarkBase {
   void setup() {
     tree = RTree<String>(BRANCH_FACTOR);
 
+    var datum = <RTreeDatum<String>>[];
     for (int i = 0; i < 100; i++) {
       for (int j = 0; j < 100; j++) {
         Rectangle rect = Rectangle(i, j, 1, 1);
-        tree.insert(RTreeDatum<String>(rect, 'item1 $i:$j'));
-        tree.insert(RTreeDatum<String>(rect, 'item2 $i:$j'));
-        tree.insert(RTreeDatum<String>(rect, 'item3 $i:$j'));
+        datum.add(RTreeDatum<String>(rect, 'item1 $i:$j'));
+        datum.add(RTreeDatum<String>(rect, 'item2 $i:$j'));
+        datum.add(RTreeDatum<String>(rect, 'item3 $i:$j'));
       }
+    }
+
+    if (useLoad) {
+      tree.load(datum);
+    } else {
+      datum.forEach(tree.insert);
     }
   }
 

--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -49,6 +49,7 @@ class InsertBenchmark extends RTreeBenchmarkBase {
   List<RTreeDatum<String>> datum;
 
   void run() {
+    tree = RTree<String>(BRANCH_FACTOR);
     for (var data in datum) {
       tree.insert(data);
     }
@@ -66,7 +67,6 @@ class InsertBenchmark extends RTreeBenchmarkBase {
           RTreeDatum<String>(Rectangle(x, y, width, height), 'item $i');
       datum.add(item);
     }
-    tree = RTree<String>(BRANCH_FACTOR);
   }
 
   void teardown() {}
@@ -79,6 +79,7 @@ class LoadBenchmark extends RTreeBenchmarkBase {
   List<RTreeDatum<String>> datum;
 
   void run() {
+    tree = RTree<String>(BRANCH_FACTOR);
     tree.load(datum);
   }
 
@@ -94,7 +95,6 @@ class LoadBenchmark extends RTreeBenchmarkBase {
           RTreeDatum<String>(Rectangle(x, y, width, height), 'item $i');
       datum.add(item);
     }
-    tree = RTree<String>(BRANCH_FACTOR);
   }
 
   void teardown() {}

--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -23,33 +23,23 @@ main() {
   SearchBenchmark(collector, totalItems: 1000, iterateAll: true).report();
   SearchBenchmark(collector, totalItems: 10000, iterateAll: true).report();
 
-  SearchBenchmark(collector, totalItems: 100, iterateAll: true, useLoad: true)
-      .report();
-  SearchBenchmark(collector, totalItems: 1000, iterateAll: true, useLoad: true)
-      .report();
-  SearchBenchmark(collector, totalItems: 10000, iterateAll: true, useLoad: true)
-      .report();
+  SearchBenchmark(collector, totalItems: 100, iterateAll: true, useLoad: true).report();
+  SearchBenchmark(collector, totalItems: 1000, iterateAll: true, useLoad: true).report();
+  SearchBenchmark(collector, totalItems: 10000, iterateAll: true, useLoad: true).report();
 
-  var longestName = collector.collected.keys
-      .reduce(
-          (value, element) => value.length > element.length ? value : element)
-      .length;
+  var longestName =
+      collector.collected.keys.reduce((value, element) => value.length > element.length ? value : element).length;
   var longestValue = collector.collected.values
-      .reduce((value, element) =>
-          value.toStringAsFixed(2).length > element.toStringAsFixed(2).length
-              ? value
-              : element)
+      .reduce((value, element) => value.toStringAsFixed(2).length > element.toStringAsFixed(2).length ? value : element)
       .toStringAsFixed(2);
   var nameHeading = 'Name';
-  var heading =
-      '$nameHeading${' ' * (longestName - nameHeading.length)}\tResult (microseconds)';
+  var heading = '$nameHeading${' ' * (longestName - nameHeading.length)}\tResult (microseconds)';
   var separator = '-' * (heading.length + 5);
   var output = '\n$heading\n$separator\n';
   collector.collected.forEach((String name, double value) {
     name += (' ' * (longestName - name.length));
     var valueString = value.toStringAsFixed(2);
-    output +=
-        '$name\t${' ' * (longestValue.length - valueString.length)}${valueString}\n';
+    output += '$name\t${' ' * (longestValue.length - valueString.length)}${valueString}\n';
   });
 
   print(output);
@@ -58,8 +48,7 @@ main() {
 class InsertBenchmark extends RTreeBenchmarkBase {
   final int totalItems;
 
-  InsertBenchmark(ScoreCollector collector, {this.totalItems = 500})
-      : super("Insert $totalItems", collector);
+  InsertBenchmark(ScoreCollector collector, {this.totalItems = 500}) : super("Insert $totalItems", collector);
 
   late RTree<String> tree;
   late List<RTreeDatum<String>> datum;
@@ -79,8 +68,7 @@ class InsertBenchmark extends RTreeBenchmarkBase {
       int y = rand.nextInt(1000);
       int height = rand.nextInt(100);
       int width = rand.nextInt(100);
-      final item =
-          RTreeDatum<String>(Rectangle(x, y, width, height), 'item $i');
+      final item = RTreeDatum<String>(Rectangle(x, y, width, height), 'item $i');
       datum.add(item);
     }
   }
@@ -91,8 +79,7 @@ class InsertBenchmark extends RTreeBenchmarkBase {
 class LoadBenchmark extends RTreeBenchmarkBase {
   final int totalItems;
 
-  LoadBenchmark(ScoreCollector collector, {required this.totalItems})
-      : super("Load $totalItems ", collector);
+  LoadBenchmark(ScoreCollector collector, {required this.totalItems}) : super("Load $totalItems ", collector);
 
   late RTree<String> tree;
   late List<RTreeDatum<String>> datum;
@@ -110,8 +97,7 @@ class LoadBenchmark extends RTreeBenchmarkBase {
       int y = rand.nextInt(1000);
       int height = rand.nextInt(100);
       int width = rand.nextInt(100);
-      final item =
-          RTreeDatum<String>(Rectangle(x, y, width, height), 'item $i');
+      final item = RTreeDatum<String>(Rectangle(x, y, width, height), 'item $i');
       datum.add(item);
     }
     datum.shuffle();
@@ -168,8 +154,7 @@ class SearchBenchmark extends RTreeBenchmarkBase {
     required this.totalItems,
     this.iterateAll = false,
     this.useLoad = false,
-  }) : super(
-            "Search${iterateAll ? '/Iterate' : ''} ${useLoad ? '(using Load)' : '(using Insert)'} ${totalItems}",
+  }) : super("Search${iterateAll ? '/Iterate' : ''} ${useLoad ? '(using Load)' : '(using Insert)'} ${totalItems}",
             collector);
 
   late RTree<String> tree;
@@ -223,9 +208,7 @@ class SearchBenchmark extends RTreeBenchmarkBase {
 class RTreeBenchmarkBase extends BenchmarkBase {
   final int iterations;
 
-  RTreeBenchmarkBase(String name, ScoreCollector collector,
-      {this.iterations = 100})
-      : super(name, emitter: collector);
+  RTreeBenchmarkBase(String name, ScoreCollector collector, {this.iterations = 100}) : super(name, emitter: collector);
 
   @override
   void exercise() {

--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -10,6 +10,7 @@ main() {
   print('Running benchmark...');
   var collector = ScoreCollector();
   InsertBenchmark(collector).report();
+  LoadBenchmark(collector).report();
   RemoveBenchmark(collector).report();
   SearchBenchmark1(collector).report();
   SearchBenchmark2(collector).report();
@@ -45,9 +46,17 @@ class InsertBenchmark extends RTreeBenchmarkBase {
   InsertBenchmark(ScoreCollector collector) : super("Insert 5k", collector);
 
   RTree<String> tree;
+  List<RTreeDatum<String>> datum;
 
   void run() {
+    for (var data in datum) {
+      tree.insert(data);
+    }
+  }
+
+  void setup() {
     Random rand = Random();
+    datum = <RTreeDatum<String>>[];
     for (int i = 0; i < 5000; i++) {
       int x = rand.nextInt(100000);
       int y = rand.nextInt(100000);
@@ -55,11 +64,36 @@ class InsertBenchmark extends RTreeBenchmarkBase {
       int width = rand.nextInt(100);
       RTreeDatum item =
           RTreeDatum<String>(Rectangle(x, y, width, height), 'item $i');
-      tree.insert(item);
+      datum.add(item);
     }
+    tree = RTree<String>(BRANCH_FACTOR);
+  }
+
+  void teardown() {}
+}
+
+class LoadBenchmark extends RTreeBenchmarkBase {
+  LoadBenchmark(ScoreCollector collector) : super("Load 5k ", collector);
+
+  RTree<String> tree;
+  List<RTreeDatum<String>> datum;
+
+  void run() {
+    tree.load(datum);
   }
 
   void setup() {
+    Random rand = Random();
+    datum = <RTreeDatum<String>>[];
+    for (int i = 0; i < 5000; i++) {
+      int x = rand.nextInt(100000);
+      int y = rand.nextInt(100000);
+      int height = rand.nextInt(100);
+      int width = rand.nextInt(100);
+      RTreeDatum item =
+          RTreeDatum<String>(Rectangle(x, y, width, height), 'item $i');
+      datum.add(item);
+    }
     tree = RTree<String>(BRANCH_FACTOR);
   }
 

--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -16,9 +16,19 @@ main() {
   SearchBenchmark1(collector, iterateAll: true).report();
   SearchBenchmark2(collector, iterateAll: true).report();
 
-  var output = '\nName\tResult (microseconds)\n';
+  var longestName = collector.collected.keys
+      .reduce(
+          (value, element) => value.length > element.length ? value : element)
+      .length;
+  var tab = '     ';
+  var nameHeading = 'Name';
+  var heading =
+      '$nameHeading${' ' * (longestName - nameHeading.length)}${tab}Result (microseconds)';
+  var separator = '-' * heading.length;
+  var output = '\n$heading\n$separator\n';
   collector.collected.forEach((String name, double value) {
-    output += '$name\t$value\n';
+    name += (' ' * (longestName - name.length));
+    output += '$name$tab$value\n';
   });
 
   print(output);

--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -4,7 +4,7 @@ import 'package:benchmark_harness/benchmark_harness.dart';
 
 import 'package:r_tree/r_tree.dart';
 
-final int branchFactor = 8;
+final int branchFactor = 16;
 final int randomSeed = 3;
 main() {
   print('Running benchmarks...');

--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -20,15 +20,22 @@ main() {
       .reduce(
           (value, element) => value.length > element.length ? value : element)
       .length;
-  var tab = '     ';
+  var longestValue = collector.collected.values
+      .reduce((value, element) =>
+          value.toStringAsFixed(2).length > element.toStringAsFixed(2).length
+              ? value
+              : element)
+      .toStringAsFixed(2);
   var nameHeading = 'Name';
   var heading =
-      '$nameHeading${' ' * (longestName - nameHeading.length)}${tab}Result (microseconds)';
-  var separator = '-' * heading.length;
+      '$nameHeading${' ' * (longestName - nameHeading.length)}\tResult (microseconds)';
+  var separator = '-' * (heading.length + 5);
   var output = '\n$heading\n$separator\n';
   collector.collected.forEach((String name, double value) {
     name += (' ' * (longestName - name.length));
-    output += '$name$tab$value\n';
+    var valueString = value.toStringAsFixed(2);
+    output +=
+        '$name\t${' ' * (longestValue.length - valueString.length)}${valueString}\n';
   });
 
   print(output);

--- a/benchmark/benchmarks.dart
+++ b/benchmark/benchmarks.dart
@@ -124,7 +124,9 @@ class RemoveBenchmark extends RTreeBenchmarkBase {
         }
 
         Rectangle rect = Rectangle(i, j, 1, 1);
-        items[i].add(RTreeDatum<String>(rect, 'item $i:$j'));
+        final datum = RTreeDatum<String>(rect, 'item $i:$j');
+        items[i].add(datum);
+        tree.insert(datum);
       }
     }
   }

--- a/example/index.html
+++ b/example/index.html
@@ -6,6 +6,10 @@
 </head>
 <body>
 <div id="app"></div>
+<button id="insert">Generate and insert (one-by-one)</button>
+<button id="load">Generate and load (bulk)</button>
+<button id="clear">Clear</button>
+
 <div>
 	<p>Click a button to switch paint brush, then click & drag to paint a rectangle, which is inserted into the RTree.  Use search to query the RTree.</p>
 	<button id="red">Red</button>
@@ -16,6 +20,8 @@
 <ol id="results">
 	<li>Add rectangles and then use search to populate the results list</li>
 </ol>
+<button id="graphviz">Generate GraphViz</button> <button id="copy">Copy Results</button>
+<pre id="output"></pre>
 <script type="application/javascript" src="/main.dart.js"></script>
 </body>
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -5,7 +5,7 @@
 	<title>r_tree example</title>
 </head>
 <body>
-<div id="app"></div>
+<div id="app" style="border: 1px solid #000000; width: min-content;"></div>
 <button id="insert">Generate and insert (one-by-one)</button>
 <button id="load">Generate and load (bulk)</button>
 <button id="clear">Clear</button>

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:html';
+import 'dart:math';
 import 'package:r_tree/r_tree.dart';
 
 Future main() async {
@@ -124,10 +125,60 @@ Future main() async {
     currentBrush = 'search';
     searchButton.style.background = 'darkgray';
   });
+
+  final makeDataset = () {
+    Random rand = Random();
+    var datum = <RTreeDatum<String>>[];
+    for (int i = 0; i < 300; i++) {
+      int startX = rand.nextInt((canvas.width / 2).floor());
+      int endX = rand.nextInt((canvas.width / 2).floor()) * 2;
+      int startY = rand.nextInt((canvas.height / 2).floor());
+      int endY = rand.nextInt((canvas.width / 2).floor()) * 2;
+      int color = rand.nextInt(2);
+      var item = RTreeDatum(
+          Rectangle.fromPoints(Point(startX, startY), Point(endX, endY)),
+          colors[color]);
+      datum.add(item);
+    }
+    return datum;
+  };
+
+  querySelector('#insert').onClick.listen((_) {
+    makeDataset().forEach(rtree.insert);
+    draw();
+  });
+
+  querySelector('#load').onClick.listen((_) {
+    rtree.load(makeDataset());
+    draw();
+  });
+
+  querySelector('#clear').onClick.listen((_) {
+    rtree = RTree<String>();
+    draw();
+  });
+
+  querySelector('#graphviz').onClick.listen((_) {
+    var output = querySelector('#output') as PreElement;
+    output.innerHtml = rtree.toGraphViz();
+  });
+
+  querySelector('#copy').onClick.listen((_) async {
+    try {
+      await window.navigator.clipboard
+          .writeText((querySelector('#output') as PreElement).innerText);
+      querySelector('#copy').style.background = 'green';
+      await Future.delayed(Duration(milliseconds: 350));
+      querySelector('#copy').style.background = '';
+    } catch (err) {
+      querySelector('#copy').style.background = 'red';
+    }
+  });
 }
 
 const String alpha = '88';
 const String red = '#ff0000$alpha';
 const String green = '#00ff00$alpha';
 const String blue = '#0000ff$alpha';
+const colors = [red, green, blue];
 String currentBrush = '$red';

--- a/example/main.dart
+++ b/example/main.dart
@@ -18,15 +18,13 @@ Future main() async {
     canvas.context2D.strokeStyle = '';
     rtree.search(Rectangle(0, 0, 700, 500)).forEach((node) {
       canvas.context2D.fillStyle = node.value;
-      canvas.context2D.fillRect(
-          node.rect.left, node.rect.top, node.rect.width, node.rect.height);
+      canvas.context2D.fillRect(node.rect.left, node.rect.top, node.rect.width, node.rect.height);
     });
 
     if (proposedX != null && proposedY != null) {
       canvas.context2D.fillStyle = '';
       canvas.context2D.strokeStyle = 'black';
-      canvas.context2D.strokeRect(
-          startX!, startY!, proposedX! - startX!, proposedY! - startY!);
+      canvas.context2D.strokeRect(startX!, startY!, proposedX! - startX!, proposedY! - startY!);
     }
   };
 
@@ -47,10 +45,8 @@ Future main() async {
 
     var target = event.currentTarget as HtmlElement;
     var boundingRect = target.getBoundingClientRect();
-    proposedX =
-        ((event.client.x - boundingRect.left) + target.scrollLeft).floor();
-    proposedY =
-        ((event.client.y - boundingRect.top) + target.scrollTop).floor();
+    proposedX = ((event.client.x - boundingRect.left) + target.scrollLeft).floor();
+    proposedY = ((event.client.y - boundingRect.top) + target.scrollTop).floor();
 
     draw();
   });
@@ -61,12 +57,10 @@ Future main() async {
 
     var target = event.currentTarget as HtmlElement;
     var boundingRect = target.getBoundingClientRect();
-    var endX =
-        ((event.client.x - boundingRect.left) + target.scrollLeft).floor();
+    var endX = ((event.client.x - boundingRect.left) + target.scrollLeft).floor();
     var endY = ((event.client.y - boundingRect.top) + target.scrollTop).floor();
 
-    var rectangle =
-        Rectangle.fromPoints(Point(startX!, startY!), Point(endX, endY));
+    var rectangle = Rectangle.fromPoints(Point(startX!, startY!), Point(endX, endY));
     if (currentBrush == 'search') {
       var resultList = querySelector('#results')!;
       resultList.children = [];
@@ -135,9 +129,7 @@ Future main() async {
       int startY = rand.nextInt((canvas.height! / 2).floor());
       int endY = rand.nextInt((canvas.width! / 2).floor()) * 2;
       int color = rand.nextInt(2);
-      var item = RTreeDatum(
-          Rectangle.fromPoints(Point(startX, startY), Point(endX, endY)),
-          colors[color]);
+      var item = RTreeDatum(Rectangle.fromPoints(Point(startX, startY), Point(endX, endY)), colors[color]);
       datum.add(item);
     }
     return datum;
@@ -166,8 +158,7 @@ Future main() async {
 
   querySelector('#copy')!.onClick.listen((_) async {
     try {
-      await window.navigator.clipboard
-          ?.writeText((querySelector('#output') as PreElement).innerText);
+      await window.navigator.clipboard?.writeText((querySelector('#output') as PreElement).innerText);
       querySelector('#copy')!.style.background = 'green';
       await Future.delayed(Duration(milliseconds: 350));
       querySelector('#copy')!.style.background = '';
@@ -198,8 +189,7 @@ String toGraphViz(Node root) {
   return output.toString();
 }
 
-void _graphVizRecurse(
-    Node node, String parent, String identifierPrefix, StringBuffer buffer) {
+void _graphVizRecurse(Node node, String parent, String identifierPrefix, StringBuffer buffer) {
   for (var i = 0; i < node.children.length; i++) {
     var child = node.children[i];
     if (child is LeafNode) {

--- a/lib/r_tree.dart
+++ b/lib/r_tree.dart
@@ -28,6 +28,8 @@ library r_tree;
 
 import 'dart:math';
 
+import 'package:r_tree/src/r_tree/quickselect.dart';
+
 part 'src/r_tree/leaf_node.dart';
 part 'src/r_tree/non_leaf_node.dart';
 part 'src/r_tree/node.dart';

--- a/lib/r_tree.dart
+++ b/lib/r_tree.dart
@@ -28,11 +28,10 @@ library r_tree;
 
 import 'dart:math';
 
-import 'package:r_tree/src/r_tree/quickselect.dart';
-
 part 'src/r_tree/leaf_node.dart';
 part 'src/r_tree/non_leaf_node.dart';
 part 'src/r_tree/node.dart';
+part 'src/r_tree/quickselect.dart';
 part 'src/r_tree/r_tree.dart';
 part 'src/r_tree/r_tree_datum.dart';
 part 'src/r_tree/r_tree_contributor.dart';

--- a/lib/src/r_tree/leaf_node.dart
+++ b/lib/src/r_tree/leaf_node.dart
@@ -22,8 +22,7 @@ class LeafNode<E> extends Node<E> {
   List<RTreeDatum<E>> _items = [];
   List<RTreeDatum<E>> get children => _items;
 
-  LeafNode(int branchFactor, {List<RTreeDatum<E>>? initialItems})
-      : super(branchFactor) {
+  LeafNode(int branchFactor, {List<RTreeDatum<E>>? initialItems}) : super(branchFactor) {
     if (initialItems != null) {
       if (initialItems.length > branchFactor) {
         throw ArgumentError.value('too many items');
@@ -41,11 +40,9 @@ class LeafNode<E> extends Node<E> {
     return LeafNode<E>(branchFactor);
   }
 
-  Iterable<RTreeDatum<E>> search(
-      Rectangle searchRect, bool Function(E item)? shouldInclude) {
-    return _items.where((RTreeDatum<E> item) =>
-        item.overlaps(searchRect) &&
-        (shouldInclude == null || shouldInclude(item.value)));
+  Iterable<RTreeDatum<E>> search(Rectangle searchRect, bool Function(E item)? shouldInclude) {
+    return _items.where(
+        (RTreeDatum<E> item) => item.overlaps(searchRect) && (shouldInclude == null || shouldInclude(item.value)));
   }
 
   Node<E>? insert(RTreeDatum<E> item) {

--- a/lib/src/r_tree/leaf_node.dart
+++ b/lib/src/r_tree/leaf_node.dart
@@ -22,7 +22,20 @@ class LeafNode<E> extends Node<E> {
   List<RTreeDatum<E>> _items = [];
   List<RTreeDatum<E>> get children => _items;
 
-  LeafNode(int branchFactor) : super(branchFactor);
+  LeafNode(int branchFactor, {List<RTreeDatum<E>>? initialItems})
+      : super(branchFactor) {
+    if (initialItems != null) {
+      if (initialItems.length > branchFactor) {
+        throw ArgumentError.value('too many items');
+      }
+      _items = initialItems;
+
+      updateBoundingRect();
+    }
+  }
+
+  @override
+  int get height => 1;
 
   Node<E> createNewNode() {
     return LeafNode<E>(branchFactor);

--- a/lib/src/r_tree/leaf_node.dart
+++ b/lib/src/r_tree/leaf_node.dart
@@ -25,7 +25,7 @@ class LeafNode<E> extends Node<E> {
   LeafNode(int branchFactor, {List<RTreeDatum<E>>? initialItems}) : super(branchFactor) {
     if (initialItems != null) {
       if (initialItems.length > branchFactor) {
-        throw ArgumentError.value('too many items');
+        throw ArgumentError('too many items');
       }
       _items = initialItems;
 

--- a/lib/src/r_tree/leaf_node.dart
+++ b/lib/src/r_tree/leaf_node.dart
@@ -19,7 +19,7 @@ part of r_tree;
 /// A [Node] that is a leaf node of the tree.  These are created automatically
 /// by [RTree] when inserting/removing items from the tree.
 class LeafNode<E> extends Node<E> {
-  List<RTreeDatum<E>> _items = [];
+  late final List<RTreeDatum<E>> _items;
   List<RTreeDatum<E>> get children => _items;
 
   LeafNode(int branchFactor, {List<RTreeDatum<E>>? initialItems}) : super(branchFactor) {
@@ -30,6 +30,8 @@ class LeafNode<E> extends Node<E> {
       _items = initialItems;
 
       updateBoundingRect();
+    } else {
+      _items = [];
     }
   }
 
@@ -55,7 +57,7 @@ class LeafNode<E> extends Node<E> {
   }
 
   clearChildren() {
-    _items = [];
+    _items.clear();
     _minimumBoundingRect = Rectangle(0, 0, 0, 0);
   }
 }

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -22,6 +22,9 @@ abstract class Node<E> extends RTreeContributor {
   /// The branch factor this node is configured with, which determines when the node should split
   final int branchFactor;
 
+  /// Height of the node, where 1 is a leaf node
+  int height = 1;
+
   /// Parent node of this node, or null if this is the root node
   Node<E>? parent;
 
@@ -82,8 +85,9 @@ abstract class Node<E> extends RTreeContributor {
     return _area(newRect) - _area(rect);
   }
 
-  num _area(Rectangle rect) =>
-      (rect.right - rect.left) * (rect.bottom - rect.top);
+  num area() => _area(rect);
+
+  num get margin => (rect.right - rect.left) + (rect.bottom - rect.top);
 
   /// Adds the rectangle containing [item] to this node's covered rectangle
   include(RTreeContributor item) {
@@ -105,6 +109,10 @@ abstract class Node<E> extends RTreeContributor {
     return _minimumBoundingRect;
   }
 
+  extend(Rectangle b) {
+    _minimumBoundingRect = _minimumBoundingRect.boundingBox(b);
+  }
+
   /// Determines if this node needs to be split and returns a new [Node] if so, otherwise returns null
   Node<E>? splitIfNecessary() => size > branchFactor ? _split() : null;
 
@@ -119,6 +127,7 @@ abstract class Node<E> extends RTreeContributor {
     addChild(seeds.seed1);
 
     Node<E> splitNode = createNewNode();
+    splitNode.height = height + 1;
     splitNode.addChild(seeds.seed2);
 
     _reassignRemainingChildren(remainingChildren, splitNode);
@@ -126,7 +135,7 @@ abstract class Node<E> extends RTreeContributor {
     return splitNode;
   }
 
-  _reassignRemainingChildren(
+  void _reassignRemainingChildren(
       List<RTreeContributor> remainingChildren, Node<E> splitNode) {
     for (var child in remainingChildren) {
       num thisExpansionCost = expansionCost(child);
@@ -203,3 +212,6 @@ class _Seeds {
 
   const _Seeds(this.seed1, this.seed2);
 }
+
+num _area(Rectangle rect) =>
+    (rect.right - rect.left) * (rect.bottom - rect.top);

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -206,4 +206,4 @@ class _Seeds {
   const _Seeds(this.seed1, this.seed2);
 }
 
-num _area(Rectangle rect) => (rect.right - rect.left) * (rect.bottom - rect.top);
+num _area(Rectangle rect) => rect.width * rect.height;

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -41,8 +41,7 @@ abstract class Node<E> extends RTreeContributor {
   Node(this.branchFactor);
 
   /// Returns an iterable of all items within [searchRect]
-  Iterable<RTreeDatum<E>> search(
-      Rectangle searchRect, bool Function(E item)? shouldInclude);
+  Iterable<RTreeDatum<E>> search(Rectangle searchRect, bool Function(E item)? shouldInclude);
 
   /// Inserts [item] into the node. If the insertion causes a split to occur, the split node will be returned, otherwise null is returned.
   Node<E>? insert(RTreeDatum<E> item);
@@ -91,9 +90,7 @@ abstract class Node<E> extends RTreeContributor {
 
   /// Adds the rectangle containing [item] to this node's covered rectangle
   include(RTreeContributor item) {
-    _minimumBoundingRect = _minimumBoundingRect == Rectangle(0, 0, 0, 0)
-        ? item.rect
-        : rect.boundingBox(item.rect);
+    _minimumBoundingRect = _minimumBoundingRect == Rectangle(0, 0, 0, 0) ? item.rect : rect.boundingBox(item.rect);
   }
 
   /// Recalculated the bounding rectangle of this node
@@ -135,8 +132,7 @@ abstract class Node<E> extends RTreeContributor {
     return splitNode;
   }
 
-  void _reassignRemainingChildren(
-      List<RTreeContributor> remainingChildren, Node<E> splitNode) {
+  void _reassignRemainingChildren(List<RTreeContributor> remainingChildren, Node<E> splitNode) {
     for (var child in remainingChildren) {
       num thisExpansionCost = expansionCost(child);
       num splitExpansionCost = splitNode.expansionCost(child);
@@ -170,8 +166,7 @@ abstract class Node<E> extends RTreeContributor {
     }
 
     RTreeContributor? a, b, c, d;
-    if (_horizontalDifference(leftmost, rightmost) >
-        _verticalDifference(topmost, bottommost)) {
+    if (_horizontalDifference(leftmost, rightmost) > _verticalDifference(topmost, bottommost)) {
       a = leftmost;
       b = rightmost;
       c = bottommost;
@@ -197,12 +192,10 @@ abstract class Node<E> extends RTreeContributor {
     return _Seeds(seed1, seed2);
   }
 
-  num _horizontalDifference(
-          RTreeContributor leftmost, RTreeContributor rightmost) =>
+  num _horizontalDifference(RTreeContributor leftmost, RTreeContributor rightmost) =>
       (rightmost.rect.left - leftmost.rect.right).abs();
 
-  num _verticalDifference(
-          RTreeContributor topmost, RTreeContributor bottommost) =>
+  num _verticalDifference(RTreeContributor topmost, RTreeContributor bottommost) =>
       (topmost.rect.bottom - bottommost.rect.top).abs();
 }
 
@@ -213,5 +206,4 @@ class _Seeds {
   const _Seeds(this.seed1, this.seed2);
 }
 
-num _area(Rectangle rect) =>
-    (rect.right - rect.left) * (rect.bottom - rect.top);
+num _area(Rectangle rect) => (rect.right - rect.left) * (rect.bottom - rect.top);

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -118,7 +118,7 @@ abstract class Node<E> extends RTreeContributor {
 
     removeChild(seeds.seed1);
     removeChild(seeds.seed2);
-    List<RTreeContributor> remainingChildren = children;
+    List<RTreeContributor> remainingChildren = children.toList();
 
     clearChildren();
     addChild(seeds.seed1);

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -106,7 +106,7 @@ abstract class Node<E> extends RTreeContributor {
     return _minimumBoundingRect;
   }
 
-  extend(Rectangle b) {
+  void extend(Rectangle b) {
     _minimumBoundingRect = _minimumBoundingRect.boundingBox(b);
   }
 

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -19,7 +19,7 @@ part of r_tree;
 /// A [Node] that is not a leaf end of the [RTree]. These are created automatically
 /// by [RTree] when inserting/removing items from the tree.
 class NonLeafNode<E> extends Node<E> {
-  List<Node<E>> _childNodes = [];
+  late final List<Node<E>> _childNodes;
   List<Node<E>> get children => _childNodes;
 
   NonLeafNode(int branchFactor, {List<Node<E>>? initialChildNodes}) : super(branchFactor) {
@@ -29,6 +29,8 @@ class NonLeafNode<E> extends Node<E> {
       }
       _childNodes = initialChildNodes;
       updateBoundingRect();
+    } else {
+      _childNodes = [];
     }
   }
 
@@ -94,7 +96,7 @@ class NonLeafNode<E> extends Node<E> {
   }
 
   clearChildren() {
-    _childNodes = [];
+    _childNodes.clear();
     _minimumBoundingRect = Rectangle(0, 0, 0, 0);
   }
 

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -25,7 +25,7 @@ class NonLeafNode<E> extends Node<E> {
   NonLeafNode(int branchFactor, {List<Node<E>>? initialChildNodes}) : super(branchFactor) {
     if (initialChildNodes != null) {
       if (initialChildNodes.length > branchFactor) {
-        throw ArgumentError.value('too many items');
+        throw ArgumentError('too many items');
       }
       _childNodes = initialChildNodes;
       updateBoundingRect();

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -22,8 +22,7 @@ class NonLeafNode<E> extends Node<E> {
   List<Node<E>> _childNodes = [];
   List<Node<E>> get children => _childNodes;
 
-  NonLeafNode(int branchFactor, {List<Node<E>>? initialChildNodes})
-      : super(branchFactor) {
+  NonLeafNode(int branchFactor, {List<Node<E>>? initialChildNodes}) : super(branchFactor) {
     if (initialChildNodes != null) {
       if (initialChildNodes.length > branchFactor) {
         throw ArgumentError.value('too many items');
@@ -37,8 +36,7 @@ class NonLeafNode<E> extends Node<E> {
     return NonLeafNode<E>(branchFactor);
   }
 
-  Iterable<RTreeDatum<E>> search(
-      Rectangle searchRect, bool Function(E item)? shouldInclude) {
+  Iterable<RTreeDatum<E>> search(Rectangle searchRect, bool Function(E item)? shouldInclude) {
     List<RTreeDatum<E>> overlappingLeafs = [];
 
     for (var childNode in _childNodes) {

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -22,7 +22,16 @@ class NonLeafNode<E> extends Node<E> {
   List<Node<E>> _childNodes = [];
   List<Node<E>> get children => _childNodes;
 
-  NonLeafNode(int branchFactor) : super(branchFactor);
+  NonLeafNode(int branchFactor, {List<Node<E>>? initialChildNodes})
+      : super(branchFactor) {
+    if (initialChildNodes != null) {
+      if (initialChildNodes.length > branchFactor) {
+        throw ArgumentError.value('too many items');
+      }
+      _childNodes = initialChildNodes;
+      updateBoundingRect();
+    }
+  }
 
   Node<E> createNewNode() {
     return NonLeafNode<E>(branchFactor);

--- a/lib/src/r_tree/quickselect.dart
+++ b/lib/src/r_tree/quickselect.dart
@@ -9,10 +9,15 @@ part of r_tree;
 multiSelect<E>(List<E> arr, int left, int right, int n, num Function(E) getter) {
   final stack = [left, right];
   final compare = (E a, E b) => getter(a).compareTo(getter(b));
+
   while (stack.isNotEmpty) {
     right = stack.removeLast();
     left = stack.removeLast();
-    if (right - left <= n) continue;
+
+    if (right - left <= n) {
+      continue;
+    }
+
     final mid = left + ((right - left).toDouble() / n / 2).ceil() * n;
     quickSelect(arr, mid, left, right, compare);
     stack.addAll([left, mid, mid, right]);

--- a/lib/src/r_tree/quickselect.dart
+++ b/lib/src/r_tree/quickselect.dart
@@ -6,8 +6,7 @@ import 'dart:math' as math;
 
 // sort an array so that items come in groups of n unsorted items, with groups sorted between each other;
 // combines selection algorithm with binary divide & conquer approach
-multiSelect<E>(
-    List<E> arr, int left, int right, int n, num Function(E) getter) {
+multiSelect<E>(List<E> arr, int left, int right, int n, num Function(E) getter) {
   final stack = [left, right];
   final compare = (E a, E b) => getter(a).compareTo(getter(b));
   while (stack.isNotEmpty) {
@@ -51,16 +50,14 @@ quickSelect<T>(List<T> arr, int k, int left, int right, Comparator<T> compare) {
   _quickSelectStep(arr, k, left, right, compare);
 }
 
-_quickSelectStep<T>(
-    List<T> arr, int k, int left, int right, Comparator<T> compare) {
+_quickSelectStep<T>(List<T> arr, int k, int left, int right, Comparator<T> compare) {
   while (right > left) {
     if (right - left > 600) {
       final n = right - left + 1;
       final m = k - left + 1;
       final z = math.log(n);
       final s = 0.5 * math.exp(2 * z / 3);
-      final sd =
-          0.5 * math.sqrt(z * s * (n - s) / n) * (m - n / 2 < 0 ? -1 : 1);
+      final sd = 0.5 * math.sqrt(z * s * (n - s) / n) * (m - n / 2 < 0 ? -1 : 1);
       final newLeft = math.max(left, (k - m * s / n + sd).floor());
       final newRight = math.min(right, (k + (n - m) * s / n + sd).floor());
       _quickSelectStep(arr, k, newLeft, newRight, compare);

--- a/lib/src/r_tree/quickselect.dart
+++ b/lib/src/r_tree/quickselect.dart
@@ -47,7 +47,7 @@ multiSelect<E>(List<E> arr, int left, int right, int n, num Function(E) getter) 
 /// // arr is [39, 28, 28, 33, 21, 12, 22, 50, 53, 56, 59, 65, 90, 77, 95]
 /// //                                         ^^ middle index
 /// ```
-quickSelect<T>(List<T> arr, int k, int left, int right, Comparator<T> compare) {
+void quickSelect<T>(List<T> arr, int k, int left, int right, Comparator<T> compare) {
   if (arr.isEmpty) {
     return;
   }
@@ -55,7 +55,7 @@ quickSelect<T>(List<T> arr, int k, int left, int right, Comparator<T> compare) {
   _quickSelectStep(arr, k, left, right, compare);
 }
 
-_quickSelectStep<T>(List<T> arr, int k, int left, int right, Comparator<T> compare) {
+void _quickSelectStep<T>(List<T> arr, int k, int left, int right, Comparator<T> compare) {
   while (right > left) {
     if (right - left > 600) {
       final n = right - left + 1;
@@ -95,7 +95,7 @@ _quickSelectStep<T>(List<T> arr, int k, int left, int right, Comparator<T> compa
   }
 }
 
-_swap<T>(List<T> arr, i, j) {
+void _swap<T>(List<T> arr, i, j) {
   final tmp = arr[i];
   arr[i] = arr[j];
   arr[j] = tmp;

--- a/lib/src/r_tree/quickselect.dart
+++ b/lib/src/r_tree/quickselect.dart
@@ -30,9 +30,9 @@ multiSelect<E>(List<E> arr, int left, int right, int n, num Function(E) getter) 
 ///
 /// - [arr]: the list to partially sort (in place)
 /// - [k]: middle index for partial sorting (as defined above)
-/// - [left]: left index of the range to sort (`0` by default)
-/// - [right]: right index (last index of the array by default)
-/// - [compare]: compare function, if items in the list are not `Comparable`.
+/// - [left]: left index of the range to sort
+/// - [right]: right index of the range to sort
+/// - [compare]: compare function
 ///
 /// Example:
 ///

--- a/lib/src/r_tree/quickselect.dart
+++ b/lib/src/r_tree/quickselect.dart
@@ -1,8 +1,5 @@
 part of r_tree;
-
-// Copyright (c) 2021 Ilya Zverev, (c) 2018 Vladimir Agafonkin.
 // Port of https://github.com/mourner/quickselect.
-// Use of this code is governed by an ISC license, see the LICENSE file.
 
 // sort an array so that items come in groups of n unsorted items, with groups sorted between each other;
 // combines selection algorithm with binary divide & conquer approach
@@ -65,6 +62,7 @@ void _quickSelectStep<T>(List<T> arr, int k, int left, int right, Comparator<T> 
       final sd = 0.5 * sqrt(z * s * (n - s) / n) * (m - n / 2 < 0 ? -1 : 1);
       final newLeft = max(left, (k - m * s / n + sd).floor());
       final newRight = min(right, (k + (n - m) * s / n + sd).floor());
+
       _quickSelectStep(arr, k, newLeft, newRight, compare);
     }
 
@@ -73,14 +71,24 @@ void _quickSelectStep<T>(List<T> arr, int k, int left, int right, Comparator<T> 
     var j = right;
 
     _swap(arr, left, k);
-    if (compare(arr[right], t) > 0) _swap(arr, left, right);
+
+    if (compare(arr[right], t) > 0) {
+      _swap(arr, left, right);
+    }
 
     while (i < j) {
       _swap(arr, i, j);
+
       i++;
       j--;
-      while (compare(arr[i], t) < 0) i++;
-      while (compare(arr[j], t) > 0) j--;
+
+      while (compare(arr[i], t) < 0) {
+        i++;
+      }
+
+      while (compare(arr[j], t) > 0) {
+        j--;
+      }
     }
 
     if (compare(arr[left], t) == 0) {
@@ -90,8 +98,12 @@ void _quickSelectStep<T>(List<T> arr, int k, int left, int right, Comparator<T> 
       _swap(arr, j, right);
     }
 
-    if (j <= k) left = j + 1;
-    if (k <= j) right = j - 1;
+    if (j <= k) {
+      left = j + 1;
+    }
+    if (k <= j) {
+      right = j - 1;
+    }
   }
 }
 

--- a/lib/src/r_tree/quickselect.dart
+++ b/lib/src/r_tree/quickselect.dart
@@ -1,0 +1,100 @@
+// Copyright (c) 2021 Ilya Zverev, (c) 2018 Vladimir Agafonkin.
+// Port of https://github.com/mourner/quickselect.
+// Use of this code is governed by an ISC license, see the LICENSE file.
+
+import 'dart:math' as math;
+
+// sort an array so that items come in groups of n unsorted items, with groups sorted between each other;
+// combines selection algorithm with binary divide & conquer approach
+multiSelect<E>(
+    List<E> arr, int left, int right, int n, num Function(E) getter) {
+  final stack = [left, right];
+  final compare = (E a, E b) => getter(a).compareTo(getter(b));
+  while (stack.isNotEmpty) {
+    right = stack.removeLast();
+    left = stack.removeLast();
+    if (right - left <= n) continue;
+    final mid = left + ((right - left).toDouble() / n / 2).ceil() * n;
+    quickSelect(arr, mid, left, right, compare);
+    stack.addAll([left, mid, mid, right]);
+  }
+}
+
+/// This function implements a fast
+/// [selection algorithm](https://en.wikipedia.org/wiki/Selection_algorithm)
+/// (specifically, [Floyd-Rivest selection](https://en.wikipedia.org/wiki/Floyd%E2%80%93Rivest_algorithm)).
+///
+/// Rearranges items so that all items in the `[left, k]` are the smallest.
+/// The `k`-th element will have the `(k - left + 1)`-th smallest value in `[left, right]`.
+///
+/// - [arr]: the list to partially sort (in place)
+/// - [k]: middle index for partial sorting (as defined above)
+/// - [left]: left index of the range to sort (`0` by default)
+/// - [right]: right index (last index of the array by default)
+/// - [compare]: compare function, if items in the list are not `Comparable`.
+///
+/// Example:
+///
+/// ```dart
+/// var arr = [65, 28, 59, 33, 21, 56, 22, 95, 50, 12, 90, 53, 28, 77, 39];
+///
+/// quickSelect(arr, 8);
+///
+/// // arr is [39, 28, 28, 33, 21, 12, 22, 50, 53, 56, 59, 65, 90, 77, 95]
+/// //                                         ^^ middle index
+/// ```
+quickSelect<T>(List<T> arr, int k, int left, int right, Comparator<T> compare) {
+  if (arr.isEmpty) {
+    return;
+  }
+
+  _quickSelectStep(arr, k, left, right, compare);
+}
+
+_quickSelectStep<T>(
+    List<T> arr, int k, int left, int right, Comparator<T> compare) {
+  while (right > left) {
+    if (right - left > 600) {
+      final n = right - left + 1;
+      final m = k - left + 1;
+      final z = math.log(n);
+      final s = 0.5 * math.exp(2 * z / 3);
+      final sd =
+          0.5 * math.sqrt(z * s * (n - s) / n) * (m - n / 2 < 0 ? -1 : 1);
+      final newLeft = math.max(left, (k - m * s / n + sd).floor());
+      final newRight = math.min(right, (k + (n - m) * s / n + sd).floor());
+      _quickSelectStep(arr, k, newLeft, newRight, compare);
+    }
+
+    final t = arr[k];
+    var i = left;
+    var j = right;
+
+    _swap(arr, left, k);
+    if (compare(arr[right], t) > 0) _swap(arr, left, right);
+
+    while (i < j) {
+      _swap(arr, i, j);
+      i++;
+      j--;
+      while (compare(arr[i], t) < 0) i++;
+      while (compare(arr[j], t) > 0) j--;
+    }
+
+    if (compare(arr[left], t) == 0) {
+      _swap(arr, left, j);
+    } else {
+      j++;
+      _swap(arr, j, right);
+    }
+
+    if (j <= k) left = j + 1;
+    if (k <= j) right = j - 1;
+  }
+}
+
+_swap<T>(List<T> arr, i, j) {
+  final tmp = arr[i];
+  arr[i] = arr[j];
+  arr[j] = tmp;
+}

--- a/lib/src/r_tree/quickselect.dart
+++ b/lib/src/r_tree/quickselect.dart
@@ -1,8 +1,8 @@
+part of r_tree;
+
 // Copyright (c) 2021 Ilya Zverev, (c) 2018 Vladimir Agafonkin.
 // Port of https://github.com/mourner/quickselect.
 // Use of this code is governed by an ISC license, see the LICENSE file.
-
-import 'dart:math' as math;
 
 // sort an array so that items come in groups of n unsorted items, with groups sorted between each other;
 // combines selection algorithm with binary divide & conquer approach
@@ -55,11 +55,11 @@ _quickSelectStep<T>(List<T> arr, int k, int left, int right, Comparator<T> compa
     if (right - left > 600) {
       final n = right - left + 1;
       final m = k - left + 1;
-      final z = math.log(n);
-      final s = 0.5 * math.exp(2 * z / 3);
-      final sd = 0.5 * math.sqrt(z * s * (n - s) / n) * (m - n / 2 < 0 ? -1 : 1);
-      final newLeft = math.max(left, (k - m * s / n + sd).floor());
-      final newRight = math.min(right, (k + (n - m) * s / n + sd).floor());
+      final z = log(n);
+      final s = 0.5 * exp(2 * z / 3);
+      final sd = 0.5 * sqrt(z * s * (n - s) / n) * (m - n / 2 < 0 ? -1 : 1);
+      final newLeft = max(left, (k - m * s / n + sd).floor());
+      final newRight = min(right, (k + (n - m) * s / n + sd).floor());
       _quickSelectStep(arr, k, newLeft, newRight, compare);
     }
 

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -52,8 +52,7 @@ class RTree<E> {
 
   // Returns all items whose rectangles overlap [searchRect]
   //  Note: Rectangles that share only a border are not considered to overlap
-  Iterable<RTreeDatum<E>> search(Rectangle searchRect,
-      {bool Function(E item)? shouldInclude}) {
+  Iterable<RTreeDatum<E>> search(Rectangle searchRect, {bool Function(E item)? shouldInclude}) {
     shouldInclude ??= (_) => true;
 
     if (_root is LeafNode<E>) {
@@ -123,8 +122,7 @@ class RTree<E> {
     insertPath.forEach((e) => e.updateBoundingRect());
   }
 
-  Node<E> _chooseSubtree(
-      Node<E> inode, Node<E> node, int level, List<Node<E>> path) {
+  Node<E> _chooseSubtree(Node<E> inode, Node<E> node, int level, List<Node<E>> path) {
     while (true) {
       path.add(node);
 
@@ -172,8 +170,7 @@ class RTree<E> {
 
     if (N <= M) {
       // reached leaf level; return leaf
-      node =
-          LeafNode(_branchFactor, initialItems: items.sublist(left, right + 1));
+      node = LeafNode(_branchFactor, initialItems: items.sublist(left, right + 1));
       return node;
     }
 
@@ -224,13 +221,10 @@ class RTree<E> {
 
     Node<E> newNode;
     if (node is LeafNode) {
-      newNode = LeafNode<E>(_branchFactor,
-          initialItems:
-              node.children.cast<RTreeDatum<E>>().sublist(splitIndex));
+      newNode = LeafNode<E>(_branchFactor, initialItems: node.children.cast<RTreeDatum<E>>().sublist(splitIndex));
       node.children.removeRange(splitIndex, node.children.length);
     } else {
-      newNode = NonLeafNode(_branchFactor,
-          initialChildNodes: node.children.cast<Node<E>>().sublist(splitIndex));
+      newNode = NonLeafNode(_branchFactor, initialChildNodes: node.children.cast<Node<E>>().sublist(splitIndex));
       node.children.removeRange(splitIndex, node.children.length);
     }
     newNode.height = node.height;
@@ -310,8 +304,7 @@ class RTree<E> {
     var margin = leftBoundingBox.margin + rightBoundingBox.margin;
 
     for (var i = m; i < M - m; i++) {
-      leftBoundingBox.extend(
-          node is LeafNode ? node.children[i].rect : node.children[i].rect);
+      leftBoundingBox.extend(node is LeafNode ? node.children[i].rect : node.children[i].rect);
       margin += leftBoundingBox.margin;
     }
 
@@ -323,8 +316,7 @@ class RTree<E> {
     return margin;
   }
 
-  Node _boundingBoxForDistribution(
-      Node<E> node, int startChild, int stopChild) {
+  Node _boundingBoxForDistribution(Node<E> node, int startChild, int stopChild) {
     final destNode = LeafNode(_branchFactor);
     destNode._minimumBoundingRect = node.children[0].rect;
 
@@ -339,8 +331,7 @@ class RTree<E> {
   }
 
   void _growTree(Node<E> node1, Node<E> node2) {
-    NonLeafNode<E> newRoot =
-        NonLeafNode<E>(_branchFactor, initialChildNodes: [node1, node2]);
+    NonLeafNode<E> newRoot = NonLeafNode<E>(_branchFactor, initialChildNodes: [node1, node2]);
     newRoot.height = _root.height + 1;
     _root = newRoot;
   }

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -18,79 +18,21 @@ part of r_tree;
 
 /// A two dimensional index of data that allows querying by rectangular areas
 class RTree<E> {
-  int _branchFactor;
+  final int _branchFactor;
   late Node<E> _root;
+  late int _minEntries;
 
   RTree([int branchFactor = 16]) : _branchFactor = branchFactor {
     if (branchFactor < 3) {
       throw ArgumentError('branchFactor must be greater than 2');
     }
+    _minEntries = max(2, (max(4, _branchFactor) * 0.4).ceil());
     _resetRoot();
   }
 
-  String toGraphViz() {
-    var output = StringBuffer('''digraph r_tree {
-    root [
-        color="gray"
-        label="root"
-    ]
-    ''');
-    _graphVizRecurse(_root, 'root', 'root', output);
+  Node<E> get currentRootNode => _root;
 
-    output.write('}');
-
-    return output.toString();
-  }
-
-  void _graphVizRecurse(
-      Node node, String parent, String identifierPrefix, StringBuffer buffer) {
-    for (var i = 0; i < node.children.length; i++) {
-      var child = node.children[i];
-      if (child is LeafNode) {
-        var id = "${identifierPrefix}LeafNode$i";
-        buffer.write('''
-      $id [
-        color="green"
-        label="LeafNode$i"
-      ]
-      $parent -> $id
-''');
-        for (var j = 0; j < child.children.length; j++) {
-          var leafChild = child.children[j];
-          var childId = "${id}LeafChild$j";
-          buffer.write('''
-"$childId" [
-  color="orange"
-  label="${leafChild.value}"
-]
-$id -> "$childId"
-''');
-        }
-      } else if (child is NonLeafNode) {
-        var id = "${identifierPrefix}ChildNode$i";
-        buffer.write('''
- $id [
-  color="brown"
-  label="ChildNode$i"
- ]
- $parent -> $id
-''');
-        _graphVizRecurse(child, id, id, buffer);
-      } else if (child is RTreeDatum) {
-        var id = "${identifierPrefix}Datum$i";
-        buffer.write('''
-"$id" [
-  color="orange"
-  label="${child.value}"
-]
-$parent -> "$id"
-''');
-      }
-    }
-  }
-
-  Node<E> get root => _root;
-
+  /// Removes [item] from the rtree
   remove(RTreeDatum<E> item) {
     _root.remove(item);
 
@@ -99,6 +41,7 @@ $parent -> "$id"
     }
   }
 
+  /// Adds [item] to the rtree
   insert(RTreeDatum<E> item) {
     final splitNode = _root.insert(item);
 
@@ -107,15 +50,7 @@ $parent -> "$id"
     }
   }
 
-  load(Iterable<RTreeDatum<E>> items) {
-    items.forEach(insert);
-  }
-
-  _resetRoot() {
-    _root = LeafNode<E>(_branchFactor);
-  }
-
-  // Returns all items whose rectangles overlap the @searchRect
+  // Returns all items whose rectangles overlap [searchRect]
   //  Note: Rectangles that share only a border are not considered to overlap
   Iterable<RTreeDatum<E>> search(Rectangle searchRect,
       {bool Function(E item)? shouldInclude}) {
@@ -128,10 +63,285 @@ $parent -> "$id"
     return _root.search(searchRect, shouldInclude);
   }
 
-  _growTree(Node<E> node1, Node<E> node2) {
-    NonLeafNode<E> newRoot = NonLeafNode<E>(_branchFactor);
-    newRoot.addChild(node1);
-    newRoot.addChild(node2);
+  /// Bulk adds all [items] to the rtree
+  load(List<RTreeDatum<E>> items) {
+    if (items.isEmpty) {
+      return this;
+    }
+
+    if (items.length < _minEntries) {
+      for (final item in items) {
+        insert(item);
+      }
+      return;
+    }
+
+    // recursively build the tree with the given data from scratch using OMT algorithm
+    Node<E> node = _build(items, 0, items.length - 1, 0);
+
+    if (_root.children.length == 0) {
+      // save as is if tree is empty
+      _root = node;
+    } else if (_root.height == node.height) {
+      // split root if trees have the same height
+      _growTree(_root, node);
+    } else {
+      if (_root.height < node.height) {
+        // swap trees if inserted one is bigger
+        final tmpNode = _root;
+        _root = node;
+        node = tmpNode;
+      }
+
+      // insert the small tree into the large tree at appropriate level
+      _insertTree(_root.height - node.height - 1, node);
+    }
+
+    return;
+  }
+
+  void _insertTree(int level, Node<E> inode) {
+    final List<Node<E>> insertPath = [];
+
+    // find the best node for accommodating the item, saving all nodes along the path too
+    final node = _chooseSubtree(inode, _root, level, insertPath);
+
+    node.children.add(inode);
+    node.updateBoundingRect();
+
+    // split on node overflow; propagate upwards if necessary
+    while (level >= 0) {
+      if (insertPath[level].children.length > _branchFactor) {
+        _split(insertPath, level);
+        level--;
+      } else {
+        break;
+      }
+    }
+
+    // fix all the bounding rectangles along the insertion path
+    insertPath.forEach((e) => e.updateBoundingRect());
+  }
+
+  Node<E> _chooseSubtree(
+      Node<E> inode, Node<E> node, int level, List<Node<E>> path) {
+    while (true) {
+      path.add(node);
+
+      if (node is LeafNode || path.length - 1 == level) {
+        break;
+      }
+
+      final nonLeafNode = node as NonLeafNode<E>;
+
+      num minArea = double.infinity;
+      num minEnlargement = double.infinity;
+      Node<E>? targetNode;
+
+      // no leaves here
+      for (final child in nonLeafNode.children) {
+        if (child is NonLeafNode<E>) {
+          final area = child.rect.width * child.rect.height;
+          final enlargement = inode.expansionCost(child);
+
+          // choose entry with the least area enlargement
+          if (enlargement < minEnlargement) {
+            minEnlargement = enlargement;
+            minArea = area < minArea ? area : minArea;
+            targetNode = child;
+          } else if (enlargement == minEnlargement) {
+            // otherwise choose one with the smallest area
+            if (area < minArea) {
+              minArea = area;
+              targetNode = child;
+            }
+          }
+        }
+      }
+
+      node = targetNode ?? nonLeafNode.children.first;
+    }
+
+    return node;
+  }
+
+  Node<E> _build(List<RTreeDatum<E>> items, int left, int right, int height) {
+    final N = right - left + 1;
+    var M = _branchFactor;
+    Node<E> node;
+
+    if (N <= M) {
+      // reached leaf level; return leaf
+      node =
+          LeafNode(_branchFactor, initialItems: items.sublist(left, right + 1));
+      return node;
+    }
+
+    if (height == 0) {
+      // target height of the bulk-loaded tree
+      height = (log(N) / log(M)).ceil();
+
+      // target number of root entries to maximize storage utilization
+      M = (N / pow(M, height - 1)).ceil();
+    }
+
+    node = NonLeafNode(_branchFactor);
+    node.height = height;
+
+    // split the items into M mostly square tiles
+
+    final N2 = (N.toDouble() / M).ceil();
+    final N1 = N2 * sqrt(M).ceil();
+
+    multiSelect(items, left, right, N1, (RTreeDatum item) => item.rect.left);
+
+    for (int i = left; i <= right; i += N1) {
+      final right2 = min(i + N1 - 1, right);
+
+      multiSelect(items, i, right2, N2, (RTreeDatum item) => item.rect.top);
+
+      for (int j = i; j <= right2; j += N2) {
+        final right3 = min(j + N2 - 1, right2);
+
+        // pack each entry recursively
+        node.children.add(_build(items, j, right3, height - 1));
+      }
+    }
+    node.updateBoundingRect();
+
+    return node;
+  }
+
+  /// split overflowed node into two
+  void _split(List<Node<E>> insertPath, int level) {
+    final node = insertPath[level];
+    final M = node.children.length;
+    final m = _minEntries;
+
+    _chooseSplitAxis(node, m, M);
+
+    final splitIndex = _chooseSplitIndex(node, m, M);
+
+    Node<E> newNode;
+    if (node is LeafNode) {
+      newNode = LeafNode<E>(_branchFactor,
+          initialItems:
+              node.children.cast<RTreeDatum<E>>().sublist(splitIndex));
+      node.children.removeRange(splitIndex, node.children.length);
+    } else {
+      newNode = NonLeafNode(_branchFactor,
+          initialChildNodes: node.children.cast<Node<E>>().sublist(splitIndex));
+      node.children.removeRange(splitIndex, node.children.length);
+    }
+    newNode.height = node.height;
+
+    node.updateBoundingRect();
+    newNode.updateBoundingRect();
+
+    if (level > 0) {
+      insertPath[level - 1].addChild(newNode);
+    } else {
+      _splitRoot(node, newNode);
+    }
+  }
+
+  /// Split root node
+  void _splitRoot(Node<E> node, Node<E> newNode) {
+    _root = NonLeafNode<E>(_branchFactor, initialChildNodes: [node, newNode]);
+    _root.height = node.height + 1;
+  }
+
+  int _chooseSplitIndex(Node<E> node, m, M) {
+    int? index;
+    num minOverlap = double.infinity;
+    num minArea = double.infinity;
+
+    for (var i = m; i <= M - m; i++) {
+      final bbox1 = _boundingBoxForDistribution(node, 0, i);
+      final bbox2 = _boundingBoxForDistribution(node, i, M);
+
+      final intersection = bbox1.rect.intersection(bbox2.rect);
+      final overlap = intersection != null ? _area(intersection) : 0;
+      final area = bbox1.area() + bbox2.area();
+
+      // choose distribution with minimum overlap
+      if (overlap < minOverlap) {
+        minOverlap = overlap;
+        index = i;
+
+        minArea = area < minArea ? area : minArea;
+      } else if (overlap == minOverlap) {
+        // otherwise choose distribution with minimum area
+        if (area < minArea) {
+          minArea = area;
+          index = i;
+        }
+      }
+    }
+
+    return index ?? M - m;
+  }
+
+  void _chooseSplitAxis(node, m, M) {
+    final xMargin = _allDistributionMargins(node, m, M, true);
+    final yMargin = _allDistributionMargins(node, m, M, false);
+
+    // if total distributions margin value is minimal for x, sort by minX,
+    // otherwise it's already sorted by minY
+    if (xMargin < yMargin) {
+      _sortChildrenBy(node, true);
+    }
+  }
+
+  void _sortChildrenBy(Node<E> node, bool sortByMinX) {
+    if (sortByMinX) {
+      node.children.sort((a, b) => a.rect.left.compareTo(b.rect.left));
+    } else {
+      node.children.sort((a, b) => a.rect.top.compareTo(b.rect.top));
+    }
+  }
+
+  /// total margin of all possible split distributions where each node is at least [m] full
+  num _allDistributionMargins(Node<E> node, int m, int M, bool sortByMinX) {
+    _sortChildrenBy(node, sortByMinX);
+
+    final leftBoundingBox = _boundingBoxForDistribution(node, 0, m);
+    final rightBoundingBox = _boundingBoxForDistribution(node, M - m, M);
+    var margin = leftBoundingBox.margin + rightBoundingBox.margin;
+
+    for (var i = m; i < M - m; i++) {
+      leftBoundingBox.extend(
+          node is LeafNode ? node.children[i].rect : node.children[i].rect);
+      margin += leftBoundingBox.margin;
+    }
+
+    for (var i = M - m - 1; i >= m; i--) {
+      rightBoundingBox.extend(node.children[i].rect);
+      margin += rightBoundingBox.margin;
+    }
+
+    return margin;
+  }
+
+  Node _boundingBoxForDistribution(
+      Node<E> node, int startChild, int stopChild) {
+    final destNode = LeafNode(_branchFactor);
+    destNode._minimumBoundingRect = node.children[0].rect;
+
+    for (int i = startChild; i < stopChild; i++) {
+      destNode.extend(node.children[i].rect);
+    }
+    return destNode;
+  }
+
+  void _resetRoot() {
+    _root = LeafNode<E>(_branchFactor);
+  }
+
+  void _growTree(Node<E> node1, Node<E> node2) {
+    NonLeafNode<E> newRoot =
+        NonLeafNode<E>(_branchFactor, initialChildNodes: [node1, node2]);
+    newRoot.height = _root.height + 1;
     _root = newRoot;
   }
 }

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -45,6 +45,10 @@ class RTree<E> {
     }
   }
 
+  load(Iterable<RTreeDatum<E>> items) {
+    items.forEach(insert);
+  }
+
   _resetRoot() {
     _root = LeafNode<E>(_branchFactor);
   }

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -29,6 +29,69 @@ class RTree<E> {
     _resetRoot();
   }
 
+  String toGraphViz() {
+    var output = StringBuffer('''digraph r_tree {
+    root [
+        color="gray"
+        label="root"
+    ]
+    ''');
+    _graphVizRecurse(_root, 'root', 'root', output);
+
+    output.write('}');
+
+    return output.toString();
+  }
+
+  void _graphVizRecurse(
+      Node node, String parent, String identifierPrefix, StringBuffer buffer) {
+    for (var i = 0; i < node.children.length; i++) {
+      var child = node.children[i];
+      if (child is LeafNode) {
+        var id = "${identifierPrefix}LeafNode$i";
+        buffer.write('''
+      $id [
+        color="green"
+        label="LeafNode$i"
+      ]
+      $parent -> $id
+''');
+        for (var j = 0; j < child.children.length; j++) {
+          var leafChild = child.children[j];
+          var childId = "${id}LeafChild$j";
+          buffer.write('''
+"$childId" [
+  color="orange"
+  label="${leafChild.value}"
+]
+$id -> "$childId"
+''');
+        }
+      } else if (child is NonLeafNode) {
+        var id = "${identifierPrefix}ChildNode$i";
+        buffer.write('''
+ $id [
+  color="brown"
+  label="ChildNode$i"
+ ]
+ $parent -> $id
+''');
+        _graphVizRecurse(child, id, id, buffer);
+      } else if (child is RTreeDatum) {
+        var id = "${identifierPrefix}Datum$i";
+        buffer.write('''
+"$id" [
+  color="orange"
+  label="${child.value}"
+]
+$parent -> "$id"
+''');
+      }
+    }
+  }
+
+  Node<E> get root => _root;
+
   remove(RTreeDatum<E> item) {
     _root.remove(item);
 

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -171,8 +171,7 @@ class RTree<E> {
 
     if (N <= M) {
       // reached leaf level; return leaf
-      node = LeafNode(_branchFactor, initialItems: items.sublist(left, right + 1));
-      return node;
+      return LeafNode(_branchFactor, initialItems: items.sublist(left, right + 1));
     }
 
     if (height == 0) {

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -64,9 +64,9 @@ class RTree<E> {
 
   /// Bulk adds all [items] to the rtree. This implementation draws heavily from
   /// https://github.com/mourner/rbush and https://github.com/Zverik/dart_rbush.
-  load(List<RTreeDatum<E>> items) {
+  void load(List<RTreeDatum<E>> items) {
     if (items.isEmpty) {
-      return this;
+      return;
     }
 
     if (items.length < _minEntries) {

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -62,7 +62,8 @@ class RTree<E> {
     return _root.search(searchRect, shouldInclude);
   }
 
-  /// Bulk adds all [items] to the rtree
+  /// Bulk adds all [items] to the rtree. This implementation draws heavily from
+  /// https://github.com/mourner/rbush and https://github.com/Zverik/dart_rbush.
   load(List<RTreeDatum<E>> items) {
     if (items.isEmpty) {
       return this;

--- a/test/r_tree/leaf_node_test.dart
+++ b/test/r_tree/leaf_node_test.dart
@@ -41,8 +41,7 @@ main() {
 
         expect(leaf.rect, equals(Rectangle(0, 0, 1, 1)));
         expect(leaf.size, equals(1));
-        expect(
-            leaf.search(Rectangle(1, 1, 1, 1), (_) => true).length, equals(0));
+        expect(leaf.search(Rectangle(1, 1, 1, 1), (_) => true).length, equals(0));
 
         leaf.clearChildren();
 

--- a/test/r_tree/node_test.dart
+++ b/test/r_tree/node_test.dart
@@ -36,8 +36,7 @@ main() {
 
         LeafNode splitNode = leafNode.splitIfNecessary() as LeafNode<dynamic>;
 
-        Iterable<RTreeDatum?> items =
-            leafNode.search(Rectangle(0, 0, 1, 10), (_) => true);
+        Iterable<RTreeDatum?> items = leafNode.search(Rectangle(0, 0, 1, 10), (_) => true);
         expect(items.length, equals(leafNode.size));
         expect(leafNode.size, equals(2));
         expect(items.contains(itemMap['Item 0']), equals(true));
@@ -64,8 +63,7 @@ main() {
 
         LeafNode splitNode = leafNode.splitIfNecessary() as LeafNode<dynamic>;
 
-        Iterable<RTreeDatum?> items =
-            leafNode.search(Rectangle(0, 0, 10, 1), (_) => true);
+        Iterable<RTreeDatum?> items = leafNode.search(Rectangle(0, 0, 10, 1), (_) => true);
         expect(items.length, equals(leafNode.size));
         expect(leafNode.size, equals(2));
         expect(items.contains(itemMap['Item 0']), equals(true));
@@ -92,8 +90,7 @@ main() {
 
         LeafNode splitNode = leafNode.splitIfNecessary() as LeafNode<dynamic>;
 
-        Iterable<RTreeDatum?> items =
-            leafNode.search(Rectangle(0, 0, 10, 1), (_) => true);
+        Iterable<RTreeDatum?> items = leafNode.search(Rectangle(0, 0, 10, 1), (_) => true);
         expect(items.length, equals(leafNode.size));
         expect(leafNode.size, equals(2));
         expect(items.contains(itemMap['Item 0']), equals(true));
@@ -111,20 +108,16 @@ main() {
       test('expansionCost correctly calculated', () {
         LeafNode node = LeafNode(3);
 
-        expect(node.expansionCost(RTreeDatum(Rectangle(0, 0, 1, 1), '')),
-            equals(1));
+        expect(node.expansionCost(RTreeDatum(Rectangle(0, 0, 1, 1), '')), equals(1));
 
         node.addChild(RTreeDatum(Rectangle(0, 0, 1, 1), ''));
 
-        expect(node.expansionCost(RTreeDatum(Rectangle(0, 0, 1, 1), '')),
-            equals(0));
-        expect(node.expansionCost(RTreeDatum(Rectangle(1, 1, 1, 1), '')),
-            equals(3));
+        expect(node.expansionCost(RTreeDatum(Rectangle(0, 0, 1, 1), '')), equals(0));
+        expect(node.expansionCost(RTreeDatum(Rectangle(1, 1, 1, 1), '')), equals(3));
 
         node.addChild(RTreeDatum(Rectangle(2, 2, 1, 1), ''));
 
-        expect(node.expansionCost(RTreeDatum(Rectangle(1, 1, 3, 3), '')),
-            equals(7));
+        expect(node.expansionCost(RTreeDatum(Rectangle(1, 1, 3, 3), '')), equals(7));
       });
     });
   });

--- a/test/r_tree/non_leaf_node_test.dart
+++ b/test/r_tree/non_leaf_node_test.dart
@@ -44,8 +44,7 @@ main() {
 
         expect(node.rect, equals(Rectangle(0, 0, 1, 1)));
         expect(node.size, equals(1));
-        expect(
-            node.search(Rectangle(1, 1, 1, 1), (_) => true).length, equals(0));
+        expect(node.search(Rectangle(1, 1, 1, 1), (_) => true).length, equals(0));
 
         node.clearChildren();
 

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -40,80 +40,101 @@ main() {
         expect(items.isEmpty, isTrue);
       });
 
-      test('search for 1 cell in large format ranges', () {
-        RTree tree = RTree(3);
-        Map itemMap = Map();
+      final addMethods = [
+        _InsertCase('insert', (RTree tree, Iterable<RTreeDatum<String>> toAdd) {
+          toAdd.forEach(tree.insert);
+        }),
+        _InsertCase('load', (RTree tree, Iterable<RTreeDatum<String>> toAdd) {
+          tree.load(toAdd);
+        })
+      ];
 
-        for (int i = 0; i < 10; i++) {
-          String itemId = 'Item $i';
-          itemMap[itemId] =
-              RTreeDatum<String>(Rectangle(i, 0, 10 - i, 10), itemId);
-          tree.insert(itemMap[itemId]);
-        }
+      for (final addMethod in addMethods) {
+        test('search for 1 cell in large format ranges (${addMethod.name})',
+            () {
+          RTree tree = RTree(3);
+          Map itemMap = Map();
+          List<RTreeDatum<String>> itemsToInsert = [];
 
-        var items = tree.search(Rectangle(0, 0, 1, 3)); // A1:A3
-        expect(items.length, equals(1));
-        expect(items.contains(itemMap['Item 0']), equals(true));
-
-        items = tree.search(Rectangle(0, 3, 1, 10)); // A3:A13
-        expect(items.length, equals(1));
-        expect(items.contains(itemMap['Item 0']), equals(true));
-
-        items = tree.search(Rectangle(4, 4, 1, 1)); // E5
-        expect(items.length, equals(5));
-        expect(items.contains(itemMap['Item 0']), equals(true));
-        expect(items.contains(itemMap['Item 1']), equals(true));
-        expect(items.contains(itemMap['Item 2']), equals(true));
-        expect(items.contains(itemMap['Item 3']), equals(true));
-        expect(items.contains(itemMap['Item 4']), equals(true));
-      });
-
-      test('insert enough items to cause split', () {
-        RTree tree = RTree(3);
-        Map itemMap = Map();
-
-        for (int i = 0; i < 5; i++) {
-          String itemId = 'Item $i';
-          itemMap[itemId] = RTreeDatum<String>(Rectangle(0, i, 1, 1), itemId);
-          tree.insert(itemMap[itemId]);
-        }
-
-        var items = tree.search(Rectangle(0, 2, 1, 1));
-        expect(items.length, equals(1));
-        expect(items.contains(itemMap['Item 2']), equals(true));
-
-        items = tree.search(Rectangle(0, 1, 1, 2));
-        expect(items.length, equals(2));
-        expect(items.contains(itemMap['Item 1']), equals(true));
-        expect(items.contains(itemMap['Item 2']), equals(true));
-
-        items = tree.search(Rectangle(0, 0, 1, 5));
-        expect(items.length, equals(5));
-        expect(items.contains(itemMap['Item 0']), equals(true));
-        expect(items.contains(itemMap['Item 1']), equals(true));
-        expect(items.contains(itemMap['Item 2']), equals(true));
-        expect(items.contains(itemMap['Item 3']), equals(true));
-        expect(items.contains(itemMap['Item 4']), equals(true));
-      });
-
-      test('insert large amount of items', () {
-        RTree tree = RTree(16);
-
-        for (int i = 0; i < 50; i++) {
-          for (int j = 0; j < 50; j++) {
-            RTreeDatum<String> item =
-                RTreeDatum<String>(Rectangle(i, j, 1, 1), 'Item $i:$j');
-            tree.insert(item);
+          for (int i = 0; i < 10; i++) {
+            String itemId = 'Item $i';
+            itemMap[itemId] =
+                RTreeDatum<String>(Rectangle(i, 0, 10 - i, 10), itemId);
+            itemsToInsert.add(itemMap[itemId]);
           }
-        }
 
-        var items = tree.search(Rectangle(31, 27, 1, 1));
-        expect(items.length, equals(1));
-        expect(items.elementAt(0).value, equals('Item 31:27'));
+          addMethod.method(tree, itemsToInsert);
 
-        items = tree.search(Rectangle(0, 0, 2, 50));
-        expect(items.length, equals(100));
-      });
+          var items = tree.search(Rectangle(0, 0, 1, 3)); // A1:A3
+          expect(items.length, equals(1));
+          expect(items.contains(itemMap['Item 0']), equals(true));
+
+          items = tree.search(Rectangle(0, 3, 1, 10)); // A3:A13
+          expect(items.length, equals(1));
+          expect(items.contains(itemMap['Item 0']), equals(true));
+
+          items = tree.search(Rectangle(4, 4, 1, 1)); // E5
+          expect(items.length, equals(5));
+          expect(items.contains(itemMap['Item 0']), equals(true));
+          expect(items.contains(itemMap['Item 1']), equals(true));
+          expect(items.contains(itemMap['Item 2']), equals(true));
+          expect(items.contains(itemMap['Item 3']), equals(true));
+          expect(items.contains(itemMap['Item 4']), equals(true));
+        });
+
+        test('insert enough items to cause split (${addMethod.name})', () {
+          RTree tree = RTree(3);
+          Map itemMap = Map();
+          List<RTreeDatum<String>> itemsToInsert = [];
+
+          for (int i = 0; i < 5; i++) {
+            String itemId = 'Item $i';
+            itemMap[itemId] = RTreeDatum<String>(Rectangle(0, i, 1, 1), itemId);
+            itemsToInsert.add(itemMap[itemId]);
+          }
+
+          addMethod.method(tree, itemsToInsert);
+
+          var items = tree.search(Rectangle(0, 2, 1, 1));
+          expect(items.length, equals(1));
+          expect(items.contains(itemMap['Item 2']), equals(true));
+
+          items = tree.search(Rectangle(0, 1, 1, 2));
+          expect(items.length, equals(2));
+          expect(items.contains(itemMap['Item 1']), equals(true));
+          expect(items.contains(itemMap['Item 2']), equals(true));
+
+          items = tree.search(Rectangle(0, 0, 1, 5));
+          expect(items.length, equals(5));
+          expect(items.contains(itemMap['Item 0']), equals(true));
+          expect(items.contains(itemMap['Item 1']), equals(true));
+          expect(items.contains(itemMap['Item 2']), equals(true));
+          expect(items.contains(itemMap['Item 3']), equals(true));
+          expect(items.contains(itemMap['Item 4']), equals(true));
+        });
+
+        test('insert large amount of items (${addMethod.name})', () {
+          RTree tree = RTree(16);
+          List<RTreeDatum<String>> itemsToInsert = [];
+
+          for (int i = 0; i < 50; i++) {
+            for (int j = 0; j < 50; j++) {
+              RTreeDatum<String> item =
+                  RTreeDatum<String>(Rectangle(i, j, 1, 1), 'Item $i:$j');
+              itemsToInsert.add(item);
+            }
+          }
+
+          addMethod.method(tree, itemsToInsert);
+
+          var items = tree.search(Rectangle(31, 27, 1, 1));
+          expect(items.length, equals(1));
+          expect(items.elementAt(0).value, equals('Item 31:27'));
+
+          items = tree.search(Rectangle(0, 0, 2, 50));
+          expect(items.length, equals(100));
+        });
+      }
     });
 
     group('Remove', () {
@@ -205,4 +226,11 @@ main() {
       });
     });
   });
+}
+
+class _InsertCase {
+  final Function(RTree tree, Iterable<RTreeDatum<String>> toAdd) method;
+  final String name;
+
+  _InsertCase(this.name, this.method);
 }

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -10,8 +10,7 @@ main() {
     group('Insert/Search', () {
       test('insert 1 item', () {
         RTree tree = RTree(3);
-        RTreeDatum<String> item =
-            RTreeDatum<String>(Rectangle(0, 0, 1, 1), 'Item 1');
+        RTreeDatum<String> item = RTreeDatum<String>(Rectangle(0, 0, 1, 1), 'Item 1');
 
         tree.insert(item);
         var items = tree.search(item.rect, shouldInclude: (_) => false);
@@ -50,16 +49,14 @@ main() {
       ];
 
       for (final addMethod in addMethods) {
-        test('search for 1 cell in large format ranges (${addMethod.name})',
-            () {
+        test('search for 1 cell in large format ranges (${addMethod.name})', () {
           RTree tree = RTree(3);
           Map itemMap = Map();
           List<RTreeDatum<String>> itemsToInsert = [];
 
           for (int i = 0; i < 10; i++) {
             String itemId = 'Item $i';
-            itemMap[itemId] =
-                RTreeDatum<String>(Rectangle(i, 0, 10 - i, 10), itemId);
+            itemMap[itemId] = RTreeDatum<String>(Rectangle(i, 0, 10 - i, 10), itemId);
             itemsToInsert.add(itemMap[itemId]);
           }
 
@@ -119,8 +116,7 @@ main() {
 
           for (int i = 0; i < 50; i++) {
             for (int j = 0; j < 50; j++) {
-              RTreeDatum<String> item =
-                  RTreeDatum<String>(Rectangle(i, j, 1, 1), 'Item $i:$j');
+              RTreeDatum<String> item = RTreeDatum<String>(Rectangle(i, j, 1, 1), 'Item $i:$j');
               itemsToInsert.add(item);
             }
           }
@@ -140,8 +136,7 @@ main() {
     group('Remove', () {
       test('remove should only remove first occurance of item', () {
         RTree tree = RTree(3);
-        RTreeDatum<String> item =
-            RTreeDatum<String>(Rectangle(0, 0, 1, 1), 'Item 1');
+        RTreeDatum<String> item = RTreeDatum<String>(Rectangle(0, 0, 1, 1), 'Item 1');
 
         tree.insert(item);
         tree.insert(item);
@@ -197,8 +192,7 @@ main() {
 
         for (int i = 0; i < 50; i++) {
           for (int j = 0; j < 50; j++) {
-            RTreeDatum item =
-                RTreeDatum<String>(Rectangle(i, j, 1, 1), 'Item $i:$j');
+            RTreeDatum item = RTreeDatum<String>(Rectangle(i, j, 1, 1), 'Item $i:$j');
             data.add(item);
             tree.insert(item);
           }
@@ -215,8 +209,7 @@ main() {
         expect(items.length, equals(0));
 
         //test inserting after removal to ensure new root leaf node functions correctly
-        tree.insert(
-            RTreeDatum<String>(Rectangle(0, 0, 1, 1), 'New Initial Item'));
+        tree.insert(RTreeDatum<String>(Rectangle(0, 0, 1, 1), 'New Initial Item'));
 
         items = tree.search(Rectangle(0, 0, 50, 50));
 

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -45,7 +45,7 @@ main() {
           toAdd.forEach(tree.insert);
         }),
         _InsertCase('load', (RTree tree, Iterable<RTreeDatum<String>> toAdd) {
-          tree.load(toAdd);
+          tree.load(toAdd.toList());
         })
       ];
 


### PR DESCRIPTION
Inserting a lot of items one by one requires a lot of extra calculations since we regrow bounding boxes each time, split and resplit nodes, etc. Instead, this new "load" method will sort the nodes being added and distribute them into nodes upfront and then add it to the tree.

Some numbers from running these benchmarks locally (in the browser with production-compiled javascript) show that load performs much better than insert and scales much slower, too:

| Count | Insert | Load | Percent Improvement
| -----| ----| -----| -----------
| 100 | 42.04 ms | 8.14 ms | 80.63%
| 1,000 | 806.13 ms | 171.08 ms | 78.78%
| 10,000 | 16.17 seconds | 2.08 seconds | 87.14%
