### PR TITLE
Performance Improvement for Load and Search

### DIFF
--- a/lib/src/r_tree/leaf_node.dart
+++ b/lib/src/r_tree/leaf_node.dart
@@ -44,7 +44,7 @@ class LeafNode<E> extends Node<E> {
 
   Iterable<RTreeDatum<E>> search(Rectangle searchRect, bool Function(E item)? shouldInclude) {
     return _items.where(
-        (RTreeDatum<E> item) => item.overlaps(searchRect) && (shouldInclude == null || shouldInclude(item.value)));
+        (RTreeDatum<E> item) => item.rect.overlaps(searchRect) && (shouldInclude == null || shouldInclude(item.value)));
   }
 
   Node<E>? insert(RTreeDatum<E> item) {

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -18,7 +18,7 @@ part of r_tree;
 
 /// A [Node] is an entry in the [RTree] for a particular rectangle.  This is an
 /// abstract class, see [LeafNode] and [NonLeafNode] for more information.
-abstract class Node<E> extends RTreeContributor {
+abstract class Node<E> implements RTreeContributor {
   /// The branch factor this node is configured with, which determines when the node should split
   final int branchFactor;
 

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -42,7 +42,7 @@ class NonLeafNode<E> extends Node<E> {
     List<RTreeDatum<E>> overlappingLeafs = [];
 
     for (var childNode in _childNodes) {
-      if (childNode.overlaps(searchRect)) {
+      if (childNode.rect.overlaps(searchRect)) {
         overlappingLeafs.addAll(childNode.search(searchRect, shouldInclude));
       }
     }
@@ -67,7 +67,7 @@ class NonLeafNode<E> extends Node<E> {
     List<Node<E>> childrenToRemove = [];
 
     for (var childNode in _childNodes) {
-      if (childNode.overlaps(item.rect)) {
+      if (childNode.rect.overlaps(item.rect)) {
         childNode.remove(item);
 
         if (childNode.size == 0) {

--- a/lib/src/r_tree/quickselect.dart
+++ b/lib/src/r_tree/quickselect.dart
@@ -3,9 +3,9 @@ part of r_tree;
 
 // sort an array so that items come in groups of n unsorted items, with groups sorted between each other;
 // combines selection algorithm with binary divide & conquer approach
-multiSelect<E>(List<E> arr, int left, int right, int n, num Function(E) getter) {
+multiSelect<E>(
+    List<E> arr, int left, int right, int n, int Function(E a, E b) compare) {
   final stack = [left, right];
-  final compare = (E a, E b) => getter(a).compareTo(getter(b));
 
   while (stack.isNotEmpty) {
     right = stack.removeLast();

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -190,12 +190,12 @@ class RTree<E> {
     final N2 = (N.toDouble() / M).ceil();
     final N1 = N2 * sqrt(M).ceil();
 
-    multiSelect(items, left, right, N1, (RTreeDatum item) => item.rect.left);
+    multiSelect(items, left, right, N1, _compareRectLeft);
 
     for (int i = left; i <= right; i += N1) {
       final right2 = min(i + N1 - 1, right);
 
-      multiSelect(items, i, right2, N2, (RTreeDatum item) => item.rect.top);
+      multiSelect(items, i, right2, N2, _compareRectTop);
 
       for (int j = i; j <= right2; j += N2) {
         final right3 = min(j + N2 - 1, right2);
@@ -331,8 +331,26 @@ class RTree<E> {
   }
 
   void _growTree(Node<E> node1, Node<E> node2) {
-    NonLeafNode<E> newRoot = NonLeafNode<E>(_branchFactor, initialChildNodes: [node1, node2]);
+    NonLeafNode<E> newRoot =
+        NonLeafNode<E>(_branchFactor, initialChildNodes: [node1, node2]);
     newRoot.height = _root.height + 1;
     _root = newRoot;
   }
 }
+
+@pragma('vm:prefer-inline')
+int _compareNumber(num a, num b) {
+  if (a == b) {
+    return 0;
+  }
+
+  return a > b ? 1 : -1;
+}
+
+@pragma('vm:prefer-inline')
+int _compareRectTop(RTreeDatum a, RTreeDatum b) =>
+    _compareNumber(a.rect.top, b.rect.top);
+
+@pragma('vm:prefer-inline')
+int _compareRectLeft(RTreeDatum a, RTreeDatum b) =>
+    _compareNumber(a.rect.left, b.rect.left);

--- a/lib/src/r_tree/r_tree_contributor.dart
+++ b/lib/src/r_tree/r_tree_contributor.dart
@@ -18,17 +18,21 @@ part of r_tree;
 
 /// The base definition of an object that exists in an [RTree]
 abstract class RTreeContributor {
-  Rectangle get rect;
+  const RTreeContributor();
 
+  Rectangle get rect;
+}
+
+extension on Rectangle {
   // Calculate if otherRect overlaps with the current rectangle
   //
   // This function is a replication of Rectangle.intersects. It differs in that
   // the inequalities are strict and do not allow for equivalences. This means
   // that the two rectangles are not considered overlapping if they share an edge.
   bool overlaps(Rectangle otherRect) {
-    return rect.left < otherRect.left + otherRect.width &&
-        otherRect.left < rect.left + rect.width &&
-        rect.top < otherRect.top + otherRect.height &&
-        otherRect.top < rect.top + rect.height;
+    return left < otherRect.left + otherRect.width &&
+        otherRect.left < left + width &&
+        top < otherRect.top + otherRect.height &&
+        otherRect.top < top + height;
   }
 }

--- a/lib/src/r_tree/r_tree_datum.dart
+++ b/lib/src/r_tree/r_tree_datum.dart
@@ -17,7 +17,7 @@
 part of r_tree;
 
 /// An [RTreeContributor] that has a piece of data attached to it
-class RTreeDatum<E> extends RTreeContributor {
+class RTreeDatum<E> implements RTreeContributor {
   final Rectangle rect;
   final E value;
 


### PR DESCRIPTION
While experimenting with the RTree, I compared my node searcher implementations using List and Queue. I noticed suboptimal performance of RTree's Load. Therefore, I made the following attempts:

```text
Before(master):

Name                                    Result (microseconds)
--------------------------------------------------------------
Insert 100                                 8643.25
Insert 1000                              209028.80
Insert 10000                            4812995.00
Load 100                                   1065.91
Load 1000                                 28855.66
Load 10000                               409432.20
Remove 5k                                479201.20
Search/Iterate (using Insert) 100         19185.07
Search/Iterate (using Insert) 1000        86072.71
Search/Iterate (using Insert) 10000      287112.00
Search/Iterate (using Load) 100           26881.30
Search/Iterate (using Load) 1000          92531.55
Search/Iterate (using Load) 10000        251928.44

Transform the comparison functions into inline closures:

Name                                    Result (microseconds)
--------------------------------------------------------------
Insert 100                                 8420.19 (97.42%)
Insert 1000                              202726.40 (96.98%)
Insert 10000                            4762420.00 (98.95%)
Load 100                                    773.25 (72.54%)
Load 1000                                 17572.26 (60.90%)
Load 10000                               220203.30 (53.78%)
Remove 5k                                464622.40 (96.96%)
Search/Iterate (using Insert) 100         19809.47 (103.25%)
Search/Iterate (using Insert) 1000        86743.25 (100.78%)
Search/Iterate (using Insert) 10000      265700.75 (92.54%)
Search/Iterate (using Load) 100           26341.89 (97.99%)
Search/Iterate (using Load) 1000          94510.14 (102.14%)
Search/Iterate (using Load) 10000        253090.75 (100.46%)

Refactor RTreeContributor (include above changes)

Name                                    Result (microseconds)
--------------------------------------------------------------
Insert 100                                 8386.57 (97.03%)
Insert 1000                              201995.90 (96.64%)
Insert 10000                            4705896.00 (97.77%)
Load 100                                    767.79 (72.03%)
Load 1000                                 16469.92 (57.08%)
Load 10000                               215497.30 (52.63%)
Remove 5k                                214634.60 (44.79%)
Search/Iterate (using Insert) 100          9971.14 (51.97%)
Search/Iterate (using Insert) 1000        38198.02 (44.38%)
Search/Iterate (using Insert) 10000      124946.12 (43.52%)
Search/Iterate (using Load) 100           14543.00 (54.10%)
Search/Iterate (using Load) 1000          49877.24 (53.90%)
Search/Iterate (using Load) 10000        127431.63 (50.58%)
```

