### PR TITLE
Variety of performance improvements

### DIFF
--- a/lib/src/r_tree/leaf_node.dart
+++ b/lib/src/r_tree/leaf_node.dart
@@ -58,6 +58,6 @@ class LeafNode<E> extends Node<E> {
 
   clearChildren() {
     _items.clear();
-    _minimumBoundingRect = Rectangle(0, 0, 0, 0);
+    _minimumBoundingRect = noMBR;
   }
 }

--- a/lib/src/r_tree/leaf_node.dart
+++ b/lib/src/r_tree/leaf_node.dart
@@ -58,6 +58,6 @@ class LeafNode<E> extends Node<E> {
 
   clearChildren() {
     _items.clear();
-    _minimumBoundingRect = noMBR;
+    _minimumBoundingRect = null;
   }
 }

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -16,7 +16,8 @@
 
 part of r_tree;
 
-const noMBR = const Rectangle(0,0,0,0);
+const noMBR = const Rectangle(0, 0, 0, 0);
+
 /// A [Node] is an entry in the [RTree] for a particular rectangle.  This is an
 /// abstract class, see [LeafNode] and [NonLeafNode] for more information.
 abstract class Node<E> extends RTreeContributor {

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -16,6 +16,7 @@
 
 part of r_tree;
 
+const noMBR = const Rectangle(0,0,0,0);
 /// A [Node] is an entry in the [RTree] for a particular rectangle.  This is an
 /// abstract class, see [LeafNode] and [NonLeafNode] for more information.
 abstract class Node<E> extends RTreeContributor {
@@ -28,11 +29,11 @@ abstract class Node<E> extends RTreeContributor {
   /// Parent node of this node, or null if this is the root node
   Node<E>? parent;
 
-  Rectangle _minimumBoundingRect = Rectangle(0, 0, 0, 0);
+  Rectangle _minimumBoundingRect = noMBR;
 
   /// Returns the rectangle this Node covers
   Rectangle get rect {
-    if (_minimumBoundingRect == Rectangle(0, 0, 0, 0)) {
+    if (_minimumBoundingRect == noMBR) {
       updateBoundingRect();
     }
     return _minimumBoundingRect;
@@ -76,7 +77,7 @@ abstract class Node<E> extends RTreeContributor {
   /// Calculates the cost (increase to _minimumBoundingRect's area)
   /// of adding a new @item to this Node
   num expansionCost(RTreeContributor item) {
-    if (_minimumBoundingRect == Rectangle(0, 0, 0, 0)) {
+    if (_minimumBoundingRect == noMBR) {
       return _area(item.rect);
     }
 
@@ -90,15 +91,15 @@ abstract class Node<E> extends RTreeContributor {
 
   /// Adds the rectangle containing [item] to this node's covered rectangle
   include(RTreeContributor item) {
-    _minimumBoundingRect = _minimumBoundingRect == Rectangle(0, 0, 0, 0) ? item.rect : rect.boundingBox(item.rect);
+    _minimumBoundingRect = _minimumBoundingRect == noMBR ? item.rect : rect.boundingBox(item.rect);
   }
 
   /// Recalculated the bounding rectangle of this node
   Rectangle updateBoundingRect() {
     if (children.isEmpty) {
-      return Rectangle(0, 0, 0, 0);
+      return noMBR;
     } else {
-      _minimumBoundingRect = Rectangle(0, 0, 0, 0);
+      _minimumBoundingRect = noMBR;
       for (var child in children) {
         include(child);
       }

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -38,7 +38,8 @@ abstract class Node<E> extends RTreeContributor {
       return _minimumBoundingRect!;
     }
 
-    return updateBoundingRect();
+    updateBoundingRect();
+    return _minimumBoundingRect ?? noMBR;
   }
 
   Node(this.branchFactor);
@@ -97,10 +98,10 @@ abstract class Node<E> extends RTreeContributor {
   }
 
   /// Recalculated the bounding rectangle of this node
-  Rectangle updateBoundingRect() {
+  void updateBoundingRect() {
     if (children.isEmpty) {
       _minimumBoundingRect = null;
-      return noMBR;
+      return;
     }
 
     var newBoundingRect = children.first.rect;
@@ -109,7 +110,7 @@ abstract class Node<E> extends RTreeContributor {
     }
 
     _minimumBoundingRect = newBoundingRect;
-    return newBoundingRect;
+    return;
   }
 
   void extend(Rectangle b) {

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -30,7 +30,7 @@ abstract class Node<E> extends RTreeContributor {
   /// Parent node of this node, or null if this is the root node
   Node<E>? parent;
 
-  Rectangle? _minimumBoundingRect = null;
+  Rectangle? _minimumBoundingRect;
 
   /// Returns the rectangle this Node covers
   Rectangle get rect {

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -97,7 +97,7 @@ class NonLeafNode<E> extends Node<E> {
 
   clearChildren() {
     _childNodes.clear();
-    _minimumBoundingRect = Rectangle(0, 0, 0, 0);
+    _minimumBoundingRect = noMBR;
   }
 
   Node<E> _getBestNodeForInsert(RTreeDatum<E> item) {

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -97,7 +97,7 @@ class NonLeafNode<E> extends Node<E> {
 
   clearChildren() {
     _childNodes.clear();
-    _minimumBoundingRect = noMBR;
+    _minimumBoundingRect = null;
   }
 
   Node<E> _getBestNodeForInsert(RTreeDatum<E> item) {

--- a/lib/src/r_tree/quickselect.dart
+++ b/lib/src/r_tree/quickselect.dart
@@ -3,8 +3,7 @@ part of r_tree;
 
 // sort an array so that items come in groups of n unsorted items, with groups sorted between each other;
 // combines selection algorithm with binary divide & conquer approach
-multiSelect<E>(
-    List<E> arr, int left, int right, int n, int Function(E a, E b) compare) {
+multiSelect<E>(List<E> arr, int left, int right, int n, int Function(E a, E b) compare) {
   final stack = [left, right];
 
   while (stack.isNotEmpty) {

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -331,8 +331,7 @@ class RTree<E> {
   }
 
   void _growTree(Node<E> node1, Node<E> node2) {
-    NonLeafNode<E> newRoot =
-        NonLeafNode<E>(_branchFactor, initialChildNodes: [node1, node2]);
+    NonLeafNode<E> newRoot = NonLeafNode<E>(_branchFactor, initialChildNodes: [node1, node2]);
     newRoot.height = _root.height + 1;
     _root = newRoot;
   }
@@ -348,9 +347,7 @@ int _compareNumber(num a, num b) {
 }
 
 @pragma('vm:prefer-inline')
-int _compareRectTop(RTreeDatum a, RTreeDatum b) =>
-    _compareNumber(a.rect.top, b.rect.top);
+int _compareRectTop(RTreeDatum a, RTreeDatum b) => _compareNumber(a.rect.top, b.rect.top);
 
 @pragma('vm:prefer-inline')
-int _compareRectLeft(RTreeDatum a, RTreeDatum b) =>
-    _compareNumber(a.rect.left, b.rect.left);
+int _compareRectLeft(RTreeDatum a, RTreeDatum b) => _compareNumber(a.rect.left, b.rect.left);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: r_tree
-version: 2.1.1
+version: 2.1.2
 description: R-tree implementation to index and query two-dimensional data
 homepage: https://github.com/Workiva/r_tree
 

--- a/test/r_tree/leaf_node_test.dart
+++ b/test/r_tree/leaf_node_test.dart
@@ -23,7 +23,7 @@ main() {
       test('adding/clearing children updates the rect', () {
         LeafNode leaf = LeafNode(3);
 
-        expect(leaf.rect, equals(null));
+        expect(leaf.rect, equals(noMBR));
         expect(leaf.size, equals(0));
 
         leaf.addChild(RTreeDatum(Rectangle(0, 0, 1, 1), 'Item 1'));
@@ -45,7 +45,7 @@ main() {
 
         leaf.clearChildren();
 
-        expect(leaf.rect, equals(null));
+        expect(leaf.rect, equals(noMBR));
         expect(leaf.size, equals(0));
       });
     });

--- a/test/r_tree/leaf_node_test.dart
+++ b/test/r_tree/leaf_node_test.dart
@@ -23,7 +23,7 @@ main() {
       test('adding/clearing children updates the rect', () {
         LeafNode leaf = LeafNode(3);
 
-        expect(leaf.rect, equals(Rectangle(0, 0, 0, 0)));
+        expect(leaf.rect, equals(null));
         expect(leaf.size, equals(0));
 
         leaf.addChild(RTreeDatum(Rectangle(0, 0, 1, 1), 'Item 1'));
@@ -45,7 +45,7 @@ main() {
 
         leaf.clearChildren();
 
-        expect(leaf.rect, equals(Rectangle(0, 0, 0, 0)));
+        expect(leaf.rect, equals(null));
         expect(leaf.size, equals(0));
       });
     });

--- a/test/r_tree/non_leaf_node_test.dart
+++ b/test/r_tree/non_leaf_node_test.dart
@@ -23,7 +23,7 @@ main() {
       test('adding/clearing children updates the rect', () {
         NonLeafNode node = NonLeafNode(3);
 
-        expect(node.rect, equals(Rectangle(0, 0, 0, 0)));
+        expect(node.rect, equals(noMBR));
         expect(node.size, equals(0));
 
         LeafNode leaf = LeafNode(3);
@@ -48,7 +48,7 @@ main() {
 
         node.clearChildren();
 
-        expect(node.rect, equals(Rectangle(0, 0, 0, 0)));
+        expect(node.rect, equals(noMBR));
         expect(node.size, equals(0));
       });
 


### PR DESCRIPTION
While profiling I saw a surprising amount of time spent on `new.Rectangle`. When we made r_tree null-safe we decided to make boundingRect non-nullable, which resulted in creating a lot of identical empty Rectangles in some cases. I've switched this to use a shared const Rectangle to represent the uninitialized state. The benchmark results are surprisingly good. We spend less time newing up instances of Rectangles and less time garbage collecting those unused instances.



javascript benchmark  | master | const Rectangle | improvement
-- | -- | -- | --
Insert 100 | 24340.42 | 24954.11 | -2.52%
Insert 1000 | 517026.75 | 493413.47 | 4.57%
Insert 10000 | 11240350.00 | 10192000.00 | 9.33%
Load 100 | 2953.30 | 3150.59 | -6.68%
Load 1000 | 66943.79 | 64563.75 | 3.56%
Load 10000 | 897272.39 | 871911.11 | 2.83%
Remove 5k | 1314433.50 | 1208266.50 | 8.08%
Search/Iterate (using Insert) 100 | 72379.49 | 63770.45 | 11.89%
Search/Iterate (using Insert) 1000 | 309299.95 | 268866.67 | 13.07%
Search/Iterate (using Insert) 10000 | 955705.56 | 797455.44 | 16.56%
Search/Iterate (using Load) 100 | 88016.66 | 77249.92 | 12.23%
Search/Iterate (using Load) 1000 | 310976.14 | 274938.14 | 11.59%
Search/Iterate (using Load) 10000 | 822033.33 | 728433.44 | 11.39%

The difference in the VM is even better in some cases, but pretty similar
VM benchmark | master | const Rectangle | improvement
-- | -- | -- | --
Insert 100 | 7569.75 | 6618.97 | 12.56%
Insert 1000 | 176100.47 | 156262.70 | 11.27%
Insert 10000 | 3841454.33 | 3383032.83 | 11.93%
Load 100 | 1409.82 | 1393.85 | 1.13%
Load 1000 | 48680.43 | 49195.70 | -1.06%
Load 10000 | 706903.56 | 712481.89 | -0.79%
Remove 5k | 357592.89 | 298343.62 | 16.57%
Search/Iterate (using Insert) 100 | 15733.93 | 14652.69 | 6.87%
Search/Iterate (using Insert) 1000 | 68642.47 | 63117.71 | 8.05%
Search/Iterate (using Insert) 10000 | 218887.00 | 196788.16 | 10.10%
Search/Iterate (using Load) 100 | 22216.95 | 21650.92 | 2.55%
Search/Iterate (using Load) 1000 | 79380.16 | 72371.68 | 8.83%
Search/Iterate (using Load) 10000 | 205157.06 | 184301.74 | 10.17%



