### PR TITLE
DT-23492 Type errors from invalid node heights

### DIFF
--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -124,7 +124,7 @@ abstract class Node<E> extends RTreeContributor {
     addChild(seeds.seed1);
 
     Node<E> splitNode = createNewNode();
-    splitNode.height = height + 1;
+    splitNode.height = height;
     splitNode.addChild(seeds.seed2);
 
     _reassignRemainingChildren(remainingChildren, splitNode);

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -79,6 +79,8 @@ class NonLeafNode<E> extends Node<E> {
     for (var child in childrenToRemove) {
       removeChild(child);
     }
+
+    _recalculateHeight();
   }
 
   addChild(Node<E> child) {
@@ -93,6 +95,8 @@ class NonLeafNode<E> extends Node<E> {
     if (_childNodes.length == 0) {
       _convertToLeafNode();
     }
+
+    _recalculateHeight();
   }
 
   clearChildren() {
@@ -123,5 +127,11 @@ class NonLeafNode<E> extends Node<E> {
     newLeafNode.include(this);
     nonLeafParent.removeChild(this);
     nonLeafParent.addChild(newLeafNode);
+  }
+
+  _recalculateHeight() {
+    height = 1 + _childNodes.fold(0, (int greatestHeight, childNode) {
+      return max(greatestHeight, childNode.height);
+    });
   }
 }

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -130,8 +130,10 @@ class NonLeafNode<E> extends Node<E> {
   }
 
   _recalculateHeight() {
-    height = 1 + _childNodes.fold(0, (int greatestHeight, childNode) {
+    final maxChildHeight = _childNodes.fold(0, (int greatestHeight, childNode) {
       return max(greatestHeight, childNode.height);
     });
+
+    height = 1 + maxChildHeight;
   }
 }

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -240,18 +240,27 @@ main() {
       test('remove all items and then reload', () {
         final tree = RTree(3);
 
-        final items = <RTreeDatum<String>>[];
+        var items = <RTreeDatum<String>>[];
         for (var i = 0; i < 20; i++) {
           final item = RTreeDatum(Rectangle(0, i, 1, 1), 'Item $i');
           items.add(item);
           tree.insert(item);
         }
 
+        var searchResult = tree.search(Rectangle(0, 0, 1, 20));
+        expect(searchResult, hasLength(20));
+
         for (final item in items) {
           tree.remove(item);
         }
 
+        searchResult = tree.search(Rectangle(0, 0, 1, 20));
+        expect(searchResult, isEmpty);
+
         tree.load(items.sublist(0, 3));
+
+        searchResult = tree.search(Rectangle(0, 0, 1, 20));
+        expect(searchResult, hasLength(3));
       });
     });
   });
@@ -294,12 +303,14 @@ int assertNodeHeightValidity<E>(RTree<E> tree, RTreeContributor contributor) {
   return 0;
 }
 
+// Serializes the tree in a human-readable form for debugging.
 String stringifyTree<E>(RTree<E> tree) {
   final buffer = StringBuffer();
   stringifyNode(buffer, tree.currentRootNode, 0);
   return buffer.toString();
 }
 
+// Serializes the subtree from [contributor] in a humnan-readable form for debugging.
 void stringifyNode<E>(StringBuffer buffer, RTreeContributor contributor, int level) {
   buffer.write('${' ' * level}${contributor.runtimeType}');
   if (contributor is Node<E>) {

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -236,6 +236,23 @@ main() {
           expect(datum.value, equals('New Initial Item'));
         });
       });
+
+      test('remove all items and then reload', () {
+        final tree = RTree(3);
+
+        final items = <RTreeDatum<String>>[];
+        for (var i = 0; i < 20; i++) {
+          final item = RTreeDatum(Rectangle(0, i, 1, 1), 'Item $i');
+          items.add(item);
+          tree.insert(item);
+        }
+
+        for (final item in items) {
+          tree.remove(item);
+        }
+
+        tree.load(items.sublist(0, 3));
+      });
     });
   });
 }

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -246,6 +246,7 @@ main() {
           items.add(item);
           tree.insert(item);
         }
+        assertTreeHeightValidity(tree);
 
         var searchResult = tree.search(Rectangle(0, 0, 1, 20));
         expect(searchResult, hasLength(20));
@@ -253,11 +254,13 @@ main() {
         for (final item in items) {
           tree.remove(item);
         }
+        assertTreeHeightValidity(tree);
 
         searchResult = tree.search(Rectangle(0, 0, 1, 20));
         expect(searchResult, isEmpty);
 
         tree.load(items.sublist(0, 3));
+        assertTreeHeightValidity(tree);
 
         searchResult = tree.search(Rectangle(0, 0, 1, 20));
         expect(searchResult, hasLength(3));


### PR DESCRIPTION
In some cases, a node's `height` can become stale/inaccurate. This can cause exceptions to occur in `load` when [we derive a target `level` from heights](https://github.com/Workiva/r_tree/blob/9ca2feefab7bb11687746a234bf815547d2260c0/lib/src/r_tree/r_tree.dart#L97) that corresponds to a leaf node because we will [subsequently attempt to append a node](https://github.com/Workiva/r_tree/blob/9ca2feefab7bb11687746a234bf815547d2260c0/lib/src/r_tree/r_tree.dart#L109) where [the leaf expects a datum](https://github.com/Workiva/r_tree/blob/9ca2feefab7bb11687746a234bf815547d2260c0/lib/src/r_tree/leaf_node.dart#L23).

This PR makes two functional changes:

- `Node._split()` will now assign `this.height` to the split node, rather than `this.height + 1`, since the split node will be a sibling to `this` node, not a parent. In the case of a root node splitting, [a new root is created with `height + 1`](https://github.com/Workiva/r_tree/blob/9ca2feefab7bb11687746a234bf815547d2260c0/lib/src/r_tree/r_tree.dart#L333-L337).
- `NonLeafNode.remove` and `NonLeafNode.removeChild` both call a new method `_recalculateHeight` which updates the node's height based on the max of its children, otherwise its height will become stale when children are removed.

Additionally, this PR strengthens unit test coverage by adding an `assertTreeHeightValidity` utility which validates all tree heights.