### PR TITLE
DT-23495 Simplify bounds, removal logic, add test coverage

### DIFF
--- a/lib/src/r_tree/leaf_node.dart
+++ b/lib/src/r_tree/leaf_node.dart
@@ -58,6 +58,6 @@ class LeafNode<E> extends Node<E> {
 
   clearChildren() {
     _items.clear();
-    _minimumBoundingRect = Rectangle(0, 0, 0, 0);
+    rect = const Rectangle(0, 0, 0, 0);
   }
 }

--- a/lib/src/r_tree/leaf_node.dart
+++ b/lib/src/r_tree/leaf_node.dart
@@ -58,6 +58,6 @@ class LeafNode<E> extends Node<E> {
 
   clearChildren() {
     _items.clear();
-    rect = const Rectangle(0, 0, 0, 0);
+    _minimumBoundingRect = const Rectangle(0, 0, 0, 0);
   }
 }

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -28,8 +28,10 @@ abstract class Node<E> extends RTreeContributor {
   /// Parent node of this node, or null if this is the root node
   Node<E>? parent;
 
+  Rectangle _minimumBoundingRect = Rectangle(0, 0, 0, 0);
+
   /// Returns the rectangle this Node covers
-  Rectangle rect = const Rectangle(0, 0, 0, 0);
+  Rectangle get rect => _minimumBoundingRect;
 
   Node(this.branchFactor);
 
@@ -69,7 +71,7 @@ abstract class Node<E> extends RTreeContributor {
   /// Calculates the cost (increase to _minimumBoundingRect's area)
   /// of adding a new @item to this Node
   num expansionCost(RTreeContributor item) {
-    if (rect == const Rectangle(0, 0, 0, 0)) {
+    if (_minimumBoundingRect == const Rectangle(0, 0, 0, 0)) {
       return _area(item.rect);
     }
 
@@ -83,23 +85,19 @@ abstract class Node<E> extends RTreeContributor {
 
   /// Adds the rectangle containing [item] to this node's covered rectangle
   include(RTreeContributor item) {
-    if (rect == const Rectangle(0, 0, 0, 0)) {
-      rect = item.rect;
-    } else {
-      rect = rect.boundingBox(item.rect);
-    }
+    _minimumBoundingRect = _minimumBoundingRect == Rectangle(0, 0, 0, 0) ? item.rect : rect.boundingBox(item.rect);
   }
 
   /// Recalculated the bounding rectangle of this node
   Rectangle updateBoundingRect() {
-    rect = const Rectangle(0, 0, 0, 0);
+    _minimumBoundingRect = const Rectangle(0, 0, 0, 0);
     children.forEach(include);
 
     return rect;
   }
 
   void extend(Rectangle b) {
-    rect = rect.boundingBox(b);
+    _minimumBoundingRect = _minimumBoundingRect.boundingBox(b);
   }
 
   /// Determines if this node needs to be split and returns a new [Node] if so, otherwise returns null

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -28,15 +28,8 @@ abstract class Node<E> extends RTreeContributor {
   /// Parent node of this node, or null if this is the root node
   Node<E>? parent;
 
-  Rectangle _minimumBoundingRect = Rectangle(0, 0, 0, 0);
-
   /// Returns the rectangle this Node covers
-  Rectangle get rect {
-    if (_minimumBoundingRect == Rectangle(0, 0, 0, 0)) {
-      updateBoundingRect();
-    }
-    return _minimumBoundingRect;
-  }
+  Rectangle rect = const Rectangle(0, 0, 0, 0);
 
   Node(this.branchFactor);
 
@@ -76,7 +69,7 @@ abstract class Node<E> extends RTreeContributor {
   /// Calculates the cost (increase to _minimumBoundingRect's area)
   /// of adding a new @item to this Node
   num expansionCost(RTreeContributor item) {
-    if (_minimumBoundingRect == Rectangle(0, 0, 0, 0)) {
+    if (rect == const Rectangle(0, 0, 0, 0)) {
       return _area(item.rect);
     }
 
@@ -90,24 +83,23 @@ abstract class Node<E> extends RTreeContributor {
 
   /// Adds the rectangle containing [item] to this node's covered rectangle
   include(RTreeContributor item) {
-    _minimumBoundingRect = _minimumBoundingRect == Rectangle(0, 0, 0, 0) ? item.rect : rect.boundingBox(item.rect);
+    if (rect == const Rectangle(0, 0, 0, 0)) {
+      rect = item.rect;
+    } else {
+      rect = rect.boundingBox(item.rect);
+    }
   }
 
   /// Recalculated the bounding rectangle of this node
   Rectangle updateBoundingRect() {
-    if (children.isEmpty) {
-      return Rectangle(0, 0, 0, 0);
-    } else {
-      _minimumBoundingRect = Rectangle(0, 0, 0, 0);
-      for (var child in children) {
-        include(child);
-      }
-    }
-    return _minimumBoundingRect;
+    rect = const Rectangle(0, 0, 0, 0);
+    children.forEach(include);
+
+    return rect;
   }
 
   void extend(Rectangle b) {
-    _minimumBoundingRect = _minimumBoundingRect.boundingBox(b);
+    rect = rect.boundingBox(b);
   }
 
   /// Determines if this node needs to be split and returns a new [Node] if so, otherwise returns null

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -101,7 +101,7 @@ class NonLeafNode<E> extends Node<E> {
 
   clearChildren() {
     _childNodes.clear();
-    _minimumBoundingRect = Rectangle(0, 0, 0, 0);
+    rect = const Rectangle(0, 0, 0, 0);
   }
 
   Node<E> _getBestNodeForInsert(RTreeDatum<E> item) {
@@ -144,6 +144,6 @@ class NonLeafNode<E> extends Node<E> {
     }
 
     this.height = height;
-    this._minimumBoundingRect = minimumBoundingRect;
+    this.rect = minimumBoundingRect;
   }
 }

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -116,9 +116,7 @@ class NonLeafNode<E> extends Node<E> {
   }
 
   _updateHeightAndBounds() {
-    this.height = 1 + _childNodes.fold(0, (int greatestHeight, childNode) {
-      return max(greatestHeight, childNode.height);
-    });;
+    this.height = 1 + _childNodes.fold(0, (int greatest, child) => max(greatest, child.height));
 
     updateBoundingRect();
   }

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -92,10 +92,6 @@ class NonLeafNode<E> extends Node<E> {
     super.removeChild(child);
     child.parent = null;
 
-    if (_childNodes.length == 0) {
-      _convertToLeafNode();
-    }
-
     _updateHeightAndBounds();
   }
 
@@ -117,15 +113,6 @@ class NonLeafNode<E> extends Node<E> {
     }
 
     return bestNode;
-  }
-
-  _convertToLeafNode() {
-    var nonLeafParent = parent as NonLeafNode<E>?;
-    if (nonLeafParent == null) return;
-
-    var newLeafNode = LeafNode<E>(this.branchFactor);
-    nonLeafParent.removeChild(this);
-    nonLeafParent.addChild(newLeafNode);
   }
 
   _updateHeightAndBounds() {

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -97,7 +97,7 @@ class NonLeafNode<E> extends Node<E> {
 
   clearChildren() {
     _childNodes.clear();
-    rect = const Rectangle(0, 0, 0, 0);
+    _minimumBoundingRect = const Rectangle(0, 0, 0, 0);
   }
 
   Node<E> _getBestNodeForInsert(RTreeDatum<E> item) {

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -129,21 +129,10 @@ class NonLeafNode<E> extends Node<E> {
   }
 
   _updateHeightAndBounds() {
-    var height = 1;
-    var minimumBoundingRect = const Rectangle<num>(0, 0, 0, 0);
+    this.height = 1 + _childNodes.fold(0, (int greatestHeight, childNode) {
+      return max(greatestHeight, childNode.height);
+    });;
 
-    if (children.isNotEmpty) {
-      height += _childNodes.fold(0, (int greatestHeight, childNode) {
-        return max(greatestHeight, childNode.height);
-      });
-
-      minimumBoundingRect = children.first.rect;
-      for (final child in children.skip(1)) {
-        minimumBoundingRect = minimumBoundingRect.boundingBox(child.rect);
-      }
-    }
-
-    this.height = height;
-    this.rect = minimumBoundingRect;
+    updateBoundingRect();
   }
 }

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -323,7 +323,7 @@ class RTree<E> {
 
   Node _boundingBoxForDistribution(Node<E> node, int startChild, int stopChild) {
     final destNode = LeafNode(_branchFactor);
-    destNode.rect = node.children[0].rect;
+    destNode._minimumBoundingRect = node.children[0].rect;
 
     for (int i = startChild; i < stopChild; i++) {
       destNode.extend(node.children[i].rect);

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -323,7 +323,7 @@ class RTree<E> {
 
   Node _boundingBoxForDistribution(Node<E> node, int startChild, int stopChild) {
     final destNode = LeafNode(_branchFactor);
-    destNode._minimumBoundingRect = node.children[0].rect;
+    destNode.rect = node.children[0].rect;
 
     for (int i = startChild; i < stopChild; i++) {
       destNode.extend(node.children[i].rect);

--- a/test/r_tree/non_leaf_node_test.dart
+++ b/test/r_tree/non_leaf_node_test.dart
@@ -51,31 +51,6 @@ main() {
         expect(node.rect, equals(Rectangle(0, 0, 0, 0)));
         expect(node.size, equals(0));
       });
-
-      test('converting an empty NonLeafNode to a LeafNode', () {
-        NonLeafNode parentNode = NonLeafNode(3);
-        NonLeafNode node = NonLeafNode(3);
-        node.parent = parentNode;
-        parentNode.addChild(node);
-        LeafNode leaf = LeafNode(3);
-        node.addChild(leaf);
-
-        var datum1 = RTreeDatum(Rectangle(0, 0, 1, 1), '');
-        var datum2 = RTreeDatum(Rectangle(0, 0, 1, 2), '');
-        node.insert(datum1);
-        node.insert(datum2);
-
-        parentNode.children.forEach((node) {
-          expect(node, isA<NonLeafNode>());
-        });
-
-        node.remove(datum1);
-        node.remove(datum2);
-
-        parentNode.children.forEach((node) {
-          expect(node, isA<LeafNode>());
-        });
-      });
     });
   });
 }

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -215,6 +215,8 @@ main() {
         }
         assertTreeValidity(tree);
 
+        expect(tree.currentRootNode, isA<NonLeafNode<dynamic>>());
+
         var items = tree.search(Rectangle(0, 0, 50, 50));
         expect(items.length, equals(2500));
 
@@ -225,6 +227,8 @@ main() {
 
         items = tree.search(Rectangle(0, 0, 50, 50));
         expect(items.length, equals(0));
+
+        expect(tree.currentRootNode, isA<LeafNode<dynamic>>());
 
         //test inserting after removal to ensure new root leaf node functions correctly
         tree.insert(RTreeDatum<String>(Rectangle(0, 0, 1, 1), 'New Initial Item'));

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -332,7 +332,9 @@ _SubtreeValidationData assertNonLeafNodeValidity<E>(RTree<E> tree, NonLeafNode<E
   var actualRect = defaultRect;
   int? maxChildHeight;
 
-  if (node.children.isNotEmpty) {
+  if (node.children.isEmpty) {
+    throw StateError('Non-leaf nodes must have at least one leaf.');
+  } else {
     for (final child in node.children) {
       if (child.parent != node) {
         throw StateError("Non-leaf child's parent reference is incorrect.");


### PR DESCRIPTION
This PR resolves empty branch accumulation, simplifies some code paths, and adds test coverage.

- Made various `Rectangle` definitions `const` (this will conflict with/be replaced by #58)
- Simplified `Rectangle get rect` by computing bounds at mutation-time rather than query-time
- Removed `_convertToLeafNode` since it only applies to the root; see commentary on 4eca138423e030511d3ab1afd12f114da3a9510f
- Simplified `_updateHeightAndBounds` by reusing `updateBoundingRect`