### PR TITLE
Change updateBoundingRect to be non-breaking

### DIFF
--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -98,10 +98,10 @@ abstract class Node<E> implements RTreeContributor {
   }
 
   /// Recalculated the bounding rectangle of this node
-  void updateBoundingRect() {
+  Rectangle updateBoundingRect() {
     if (children.isEmpty) {
       _minimumBoundingRect = null;
-      return;
+      return noMBR;
     }
 
     var newBoundingRect = children.first.rect;
@@ -110,7 +110,7 @@ abstract class Node<E> implements RTreeContributor {
     }
 
     _minimumBoundingRect = newBoundingRect;
-    return;
+    return _minimumBoundingRect!;
   }
 
   void extend(Rectangle b) {


### PR DESCRIPTION
We technically made a [breaking change](https://github.com/Workiva/r_tree/pull/58/files#diff-868e4e4be000d12335d3da884d46d688859995541888c2319b3d405f509eab36L97) by changing the signature of updateBoundingRect since we currently expose Node (and all other symbols) as public API. This PR patches that up. In a future PR, we will clean up our public API.