### PR TITLE
Fix load state errors

### DIFF
--- a/lib/src/r_tree/leaf_node.dart
+++ b/lib/src/r_tree/leaf_node.dart
@@ -19,19 +19,15 @@ part of r_tree;
 /// A [Node] that is a leaf node of the tree.  These are created automatically
 /// by [RTree] when inserting/removing items from the tree.
 class LeafNode<E> extends Node<E> {
-  late final List<RTreeDatum<E>> _items;
+  final List<RTreeDatum<E>> _items = [];
   List<RTreeDatum<E>> get children => _items;
 
-  LeafNode(int branchFactor, {List<RTreeDatum<E>>? initialItems}) : super(branchFactor) {
-    if (initialItems != null) {
-      if (initialItems.length > branchFactor) {
-        throw ArgumentError('too many items');
-      }
-      _items = initialItems;
-
-      updateBoundingRect();
-    } else {
-      _items = [];
+  LeafNode(int branchFactor, {List<RTreeDatum<E>> initialItems = const []}) : super(branchFactor) {
+    if (initialItems.length > branchFactor) {
+      throw ArgumentError('too many items');
+    }
+    for (final item in initialItems) {
+      addChild(item);
     }
   }
 

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -28,6 +28,7 @@ class NonLeafNode<E> extends Node<E> {
         throw ArgumentError('too many items');
       }
       _childNodes = initialChildNodes;
+      _childNodes.forEach((element) { element.parent = this; });
       updateBoundingRect();
     } else {
       _childNodes = [];

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -28,7 +28,9 @@ class NonLeafNode<E> extends Node<E> {
         throw ArgumentError('too many items');
       }
       _childNodes = initialChildNodes;
-      _childNodes.forEach((element) { element.parent = this; });
+      _childNodes.forEach((element) {
+        element.parent = this;
+      });
       updateBoundingRect();
     } else {
       _childNodes = [];

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -19,21 +19,16 @@ part of r_tree;
 /// A [Node] that is not a leaf end of the [RTree]. These are created automatically
 /// by [RTree] when inserting/removing items from the tree.
 class NonLeafNode<E> extends Node<E> {
-  late final List<Node<E>> _childNodes;
+  final List<Node<E>> _childNodes = [];
   List<Node<E>> get children => _childNodes;
 
-  NonLeafNode(int branchFactor, {List<Node<E>>? initialChildNodes}) : super(branchFactor) {
-    if (initialChildNodes != null) {
-      if (initialChildNodes.length > branchFactor) {
-        throw ArgumentError('too many items');
-      }
-      _childNodes = initialChildNodes;
-      _childNodes.forEach((element) {
-        element.parent = this;
-      });
-      updateBoundingRect();
-    } else {
-      _childNodes = [];
+  NonLeafNode(int branchFactor, {List<Node<E>> initialChildNodes = const []}) : super(branchFactor) {
+    if (initialChildNodes.length > branchFactor) {
+      throw ArgumentError('too many items');
+    }
+
+    for (final child in initialChildNodes) {
+      addChild(child);
     }
   }
 

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -121,7 +121,7 @@ class RTree<E> {
     }
 
     // fix all the bounding rectangles along the insertion path
-    insertPath.forEach((e) => e.updateBoundingRect());
+    insertPath.reversed.forEach((e) => e.updateBoundingRect());
   }
 
   Node<E> _chooseSubtree(Node<E> inode, Node<E> node, int level, List<Node<E>> path) {

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -269,6 +269,26 @@ main() {
         searchResult = tree.search(Rectangle(0, 0, 1, 20));
         expect(searchResult, hasLength(3));
       });
+
+      test('has correct parents after _split', () {
+        final tree = RTree(3);
+
+        var items = <RTreeDatum<String>>[];
+        for (var i = 0; i < 1; i++) {
+          final item = RTreeDatum(Rectangle(0, i, 1, 1), 'Item $i');
+          items.add(item);
+        }
+        tree.load(items);
+        assertTreeValidity(tree);
+
+        var otherItems = <RTreeDatum<String>>[];
+        for (var i = 0; i < 20; i++) {
+          final item = RTreeDatum(Rectangle(i+10, 0, 1, 1), 'Item $i');
+          otherItems.add(item);
+        }
+        tree.load(otherItems);
+        assertTreeValidity(tree);
+      });
     });
   });
 }

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -293,28 +293,75 @@ main() {
       test('has correct parents and bounds after multiple _splits', () {
         final tree = RTree(3);
 
-        var items = <RTreeDatum<String>>[];
-        for (var i = 0; i < 1; i++) {
-          final item = RTreeDatum(Rectangle(0, i, 1, 1), 'Item $i');
-          items.add(item);
-        }
+        var items = <RTreeDatum<String>>[RTreeDatum(Rectangle(0, 0, 1, 1), 'Item 0')];
         tree.load(items);
         assertTreeValidity(tree);
 
-        var otherItems = <RTreeDatum<String>>[];
-        for (var i = 0; i < 20; i++) {
-          final item = RTreeDatum(Rectangle(i + 10, 0, 1, 1), 'Item $i');
-          otherItems.add(item);
-        }
-        tree.load(otherItems);
+        items = List<RTreeDatum<String>>.generate(
+          20,
+          (index) => RTreeDatum(
+            Rectangle(index + 10, 0, 1, 1),
+            'Item $index',
+          ),
+        );
+        ;
+        tree.load(items);
         assertTreeValidity(tree);
 
-        var secondItems = <RTreeDatum<String>>[];
-        for (var i = 0; i < 3; i++) {
-          final item = RTreeDatum(Rectangle(0, i + 10, 1, 1), 'Item $i');
-          secondItems.add(item);
-        }
-        tree.load(secondItems);
+        items = List<RTreeDatum<String>>.generate(
+          3,
+          (index) => RTreeDatum(
+            Rectangle(0, index + 10, 1, 1),
+            'Item $index',
+          ),
+        );
+        tree.load(items);
+        expect(tree.search(Rectangle(0, 0, 50, 50)), hasLength(24));
+        assertTreeValidity(tree);
+      });
+
+      test('returns correct items after multiple load calls', () {
+        final tree = RTree(3);
+
+        var items = <RTreeDatum<String>>[
+          RTreeDatum(
+            Rectangle(0, 0, 1, 1),
+            'Item 0',
+          )
+        ];
+        tree.load(items);
+
+        items = List<RTreeDatum<String>>.generate(
+          20,
+          (i) => RTreeDatum(
+            Rectangle(i, 0, 1, 1),
+            'Item $i',
+          ),
+        );
+        tree.load(items);
+
+        items = List<RTreeDatum<String>>.generate(
+          30,
+          (i) => RTreeDatum(
+            Rectangle(i, 0, 1, 1),
+            'Item $i',
+          ),
+        );
+        tree.load(items);
+
+        items = List<RTreeDatum<String>>.generate(
+          3,
+          (i) => RTreeDatum(
+            Rectangle(0, i, 1, 1),
+            'Item $i',
+          ),
+        );
+        tree.load(items);
+
+        // the test is a bit convoluted but the key here is the search rectangle
+        // intersects what the subtree's rectangle should be but not what it is
+        // if it wasn't recalculated after its children
+        expect(tree.search(Rectangle(0, 1, 20, 100)), hasLength(2));
         assertTreeValidity(tree);
       });
     });

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -283,7 +283,7 @@ main() {
 
         var otherItems = <RTreeDatum<String>>[];
         for (var i = 0; i < 20; i++) {
-          final item = RTreeDatum(Rectangle(i+10, 0, 1, 1), 'Item $i');
+          final item = RTreeDatum(Rectangle(i + 10, 0, 1, 1), 'Item $i');
           otherItems.add(item);
         }
         tree.load(otherItems);
@@ -303,7 +303,7 @@ main() {
 
         var otherItems = <RTreeDatum<String>>[];
         for (var i = 0; i < 20; i++) {
-          final item = RTreeDatum(Rectangle(i+10, 0, 1, 1), 'Item $i');
+          final item = RTreeDatum(Rectangle(i + 10, 0, 1, 1), 'Item $i');
           otherItems.add(item);
         }
         tree.load(otherItems);
@@ -311,7 +311,7 @@ main() {
 
         var secondItems = <RTreeDatum<String>>[];
         for (var i = 0; i < 3; i++) {
-          final item = RTreeDatum(Rectangle(0, i+10, 1, 1), 'Item $i');
+          final item = RTreeDatum(Rectangle(0, i + 10, 1, 1), 'Item $i');
           secondItems.add(item);
         }
         tree.load(secondItems);

--- a/test/r_tree/r_tree_test.dart
+++ b/test/r_tree/r_tree_test.dart
@@ -289,6 +289,34 @@ main() {
         tree.load(otherItems);
         assertTreeValidity(tree);
       });
+
+      test('has correct parents and bounds after multiple _splits', () {
+        final tree = RTree(3);
+
+        var items = <RTreeDatum<String>>[];
+        for (var i = 0; i < 1; i++) {
+          final item = RTreeDatum(Rectangle(0, i, 1, 1), 'Item $i');
+          items.add(item);
+        }
+        tree.load(items);
+        assertTreeValidity(tree);
+
+        var otherItems = <RTreeDatum<String>>[];
+        for (var i = 0; i < 20; i++) {
+          final item = RTreeDatum(Rectangle(i+10, 0, 1, 1), 'Item $i');
+          otherItems.add(item);
+        }
+        tree.load(otherItems);
+        assertTreeValidity(tree);
+
+        var secondItems = <RTreeDatum<String>>[];
+        for (var i = 0; i < 3; i++) {
+          final item = RTreeDatum(Rectangle(0, i+10, 1, 1), 'Item $i');
+          secondItems.add(item);
+        }
+        tree.load(secondItems);
+        assertTreeValidity(tree);
+      });
     });
   });
 }


### PR DESCRIPTION
I discovered a couple of issues with r_tree's internal state after repeated calls to the load method, one of which is significant in that selected subtrees (usually the root node) can end up with a bounding rect that doesn't encompass all their children. This could result in items not returning from a search that should be.