### PR TITLE
Deprecate symbols not intended to be public for upcoming 3.0 release

### DIFF
--- a/lib/src/r_tree/leaf_node.dart
+++ b/lib/src/r_tree/leaf_node.dart
@@ -18,6 +18,7 @@ part of r_tree;
 
 /// A [Node] that is a leaf node of the tree.  These are created automatically
 /// by [RTree] when inserting/removing items from the tree.
+@Deprecated('For internal use only, removed in next major release')
 class LeafNode<E> extends Node<E> {
   final List<RTreeDatum<E>> _items = [];
   List<RTreeDatum<E>> get children => _items;

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -16,6 +16,7 @@
 
 part of r_tree;
 
+@Deprecated('For internal use only, removed in next major release')
 const noMBR = Rectangle<num>(0, 0, 0, 0);
 
 /// A [Node] is an entry in the [RTree] for a particular rectangle.  This is an

--- a/lib/src/r_tree/node.dart
+++ b/lib/src/r_tree/node.dart
@@ -20,6 +20,7 @@ const noMBR = Rectangle<num>(0, 0, 0, 0);
 
 /// A [Node] is an entry in the [RTree] for a particular rectangle.  This is an
 /// abstract class, see [LeafNode] and [NonLeafNode] for more information.
+@Deprecated('For internal use only, removed in next major release')
 abstract class Node<E> implements RTreeContributor {
   /// The branch factor this node is configured with, which determines when the node should split
   final int branchFactor;

--- a/lib/src/r_tree/non_leaf_node.dart
+++ b/lib/src/r_tree/non_leaf_node.dart
@@ -18,6 +18,7 @@ part of r_tree;
 
 /// A [Node] that is not a leaf end of the [RTree]. These are created automatically
 /// by [RTree] when inserting/removing items from the tree.
+@Deprecated('For internal use only, removed in next major release')
 class NonLeafNode<E> extends Node<E> {
   final List<Node<E>> _childNodes = [];
   List<Node<E>> get children => _childNodes;

--- a/lib/src/r_tree/quickselect.dart
+++ b/lib/src/r_tree/quickselect.dart
@@ -3,6 +3,7 @@ part of r_tree;
 
 // sort an array so that items come in groups of n unsorted items, with groups sorted between each other;
 // combines selection algorithm with binary divide & conquer approach
+@Deprecated('For internal use only, removed in next major release')
 multiSelect<E>(List<E> arr, int left, int right, int n, int Function(E a, E b) compare) {
   final stack = [left, right];
 
@@ -43,6 +44,7 @@ multiSelect<E>(List<E> arr, int left, int right, int n, int Function(E a, E b) c
 /// // arr is [39, 28, 28, 33, 21, 12, 22, 50, 53, 56, 59, 65, 90, 77, 95]
 /// //                                         ^^ middle index
 /// ```
+@Deprecated('For internal use only, removed in next major release')
 void quickSelect<T>(List<T> arr, int k, int left, int right, Comparator<T> compare) {
   if (arr.isEmpty) {
     return;

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -33,6 +33,15 @@ class RTree<E> {
   @Deprecated('For internal use only, removed in next major release')
   Node<E> get currentRootNode => _root;
 
+  void add(List<RTreeDatum<E>> items) {
+    if (items.length == 1) {
+      insert(items.first);
+      return;
+    }
+
+    load(items);
+  }
+
   /// Removes [item] from the rtree
   remove(RTreeDatum<E> item) {
     _root.remove(item);
@@ -43,6 +52,7 @@ class RTree<E> {
   }
 
   /// Adds [item] to the rtree
+  @Deprecated('Use add')
   insert(RTreeDatum<E> item) {
     final splitNode = _root.insert(item);
 
@@ -65,6 +75,7 @@ class RTree<E> {
 
   /// Bulk adds all [items] to the rtree. This implementation draws heavily from
   /// https://github.com/mourner/rbush and https://github.com/Zverik/dart_rbush.
+  @Deprecated('Use add')
   void load(List<RTreeDatum<E>> items) {
     if (items.isEmpty) {
       return;

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -33,6 +33,7 @@ class RTree<E> {
   @Deprecated('For internal use only, removed in next major release')
   Node<E> get currentRootNode => _root;
 
+  /// Adds all [items] to the rtree
   void add(List<RTreeDatum<E>> items) {
     if (items.length == 1) {
       insert(items.first);

--- a/lib/src/r_tree/r_tree.dart
+++ b/lib/src/r_tree/r_tree.dart
@@ -30,6 +30,7 @@ class RTree<E> {
     _resetRoot();
   }
 
+  @Deprecated('For internal use only, removed in next major release')
   Node<E> get currentRootNode => _root;
 
   /// Removes [item] from the rtree


### PR DESCRIPTION
Our public API is basically the entire library, unintentionally. This PR marks the things we don't export on purpose as deprecated in preparation for removing them from the public scope in 3.0. It also consolidates the insert/load methods into an add method.

You can run `dart doc` locally to quickly view the public API. In this PR you'll see most everything crossed at due to being deprecated, leaving behind only:
- RTree<E>
- RTreeContributor
- RTreeDatum<E>